### PR TITLE
feat(core): add profile data model and parameter schema (Phase 9.0)

### DIFF
--- a/github/ISSUES/phase-9.0-profile-data-model.md
+++ b/github/ISSUES/phase-9.0-profile-data-model.md
@@ -1,0 +1,125 @@
+# Phase 9.0 — Profile Data Model & Registry
+
+**Status:** Planned  
+**Owner:** @stratifyai-core  
+**Target Release:** Phase 9 (Profiles)  
+**Last Updated:** 2026-02-28
+
+---
+
+## 1. Summary
+
+Implement the foundational profile data model and registry for StratifyAI. Profiles encapsulate reusable configuration bundles (temperature, max tokens, reasoning depth, cost sensitivity, multimodal flag, JSON enforcement, tool availability, router hints) that can be applied across providers and models. This issue covers the core infrastructure: dataclasses, validation logic, YAML loading with inheritance, and tests. Follow-up issues will handle CLI/API/ChatBuilder integration.
+
+---
+
+## 2. Goals
+
+- Define strongly-typed profile dataclasses (`Profile`, `ProfileParameter`).
+- Implement a lazy-loaded profile registry that supports inheritance (`extends`), user overrides, and validation against model capabilities.
+- Provide built-in profiles (fast, balanced, reasoning, vision, json, cheap) with YAML definitions.
+- Ensure extensibility for future profile additions (router hints, structured outputs).
+
+---
+
+## 3. Acceptance Criteria
+
+- [ ] `stratifyai/profiles/models.py` contains dataclasses with full type hints and docstrings.
+- [ ] `stratifyai/profiles/registry.py` loads built-in profiles and user overrides, resolves inheritance, and validates configurations.
+- [ ] Built-in profiles defined in `stratifyai/profiles/profiles.yaml` pass validation.
+- [ ] Validation detects capability mismatches (vision, JSON mode, tool use, etc.) when rendered for a provider/model.
+- [ ] Unit tests cover registry loading, inheritance, validation, and override precedence.
+- [ ] Developer documentation (docstrings + inline comments) explains how to add future profiles.
+
+---
+
+## 4. Deliverables
+
+1. **Data Model**
+   - `ProfileParameter` metadata (name, type, description, ranges, choices, defaults).
+   - `Profile` dataclass (name, description, parameters dict, tags, extends, source, notes).
+
+2. **Registry**
+   - Singleton registry with lazy loading.
+   - Load order: built-in YAML → user overrides (`~/.stratifyai/profiles/`).
+   - Methods: `list`, `get`, `render`, `validate`, `register`, `reload` (optional).
+   - Inheritance resolution with cycle detection.
+   - Validation against model catalog capabilities.
+
+3. **Built-in Profiles**
+   - `stratifyai/profiles/profiles.yaml` with six baseline profiles.
+   - Documentation of intended usage and compatibility notes.
+
+4. **Tests**
+   - New test module `tests/test_profiles.py`.
+   - Coverage for happy paths, inheritance, validation failures, user overrides.
+
+---
+
+## 5. Implementation Plan
+
+1. **Scaffold Module & Dataclasses**
+   - Create `stratifyai/profiles/models.py` with dataclasses and validation helpers.
+   - Add convenience enums/constants for parameter types/choices.
+
+2. **Registry & Loader**
+   - Implement registry class with internal cache.
+   - YAML parsing via `yaml.safe_load` (handle missing keys, wrong types).
+   - Merge profiles with inheritance; raise descriptive errors on cycles or missing parents.
+
+3. **Built-in Profiles**
+   - Translate roadmap defaults into YAML.
+   - Add tags for filtering (speed, reasoning, etc.).
+
+4. **Validation Logic**
+   - Integrate model catalog metadata (vision/tools/json flags).
+   - Create helper that accepts provider/model and raises informative errors.
+
+5. **Testing**
+   - Use fixtures/mocks for catalog and capability checks.
+  - Test user override directory via temporary path.
+
+6. **Documentation & Cleanup**
+   - Docstrings, inline comments, and developer journal update.
+   - Prepare follow-up issues for CLI/API/ChatBuilder integration.
+
+---
+
+## 6. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Inheritance loops cause infinite recursion | Low | High | Add cycle detection with ancestor tracking. |
+| Capability metadata missing for new models | Medium | Medium | Fallback warnings + regression tests referencing catalog schema. |
+| User YAML errors reduce discoverability | Medium | Low | Provide clear error messages and future docs (`docs/PROFILE-SYSTEM.md`). |
+| Conflicting overrides lead to unexpected behavior | Medium | Medium | Document precedence (explicit > profile > defaults) and enforce in tests. |
+
+---
+
+## 7. Related Work
+
+- `docs/DEV-SPEC-StratifyAI-WORKFLOW.md` — Phase 9 implementation details.
+- `docs/PROFILE-SYSTEM-PLAN.md` — Engineering plan for profiles (this issue covers sections 5–8).
+- `docs/PROFILE-SYSTEM.md` — User guide (to be completed as parts land).
+
+---
+
+## 8. Follow-up Issues
+
+1. **Phase 9.1** — Profile integration with ChatBuilder/CLI/API.
+2. **Phase 9.2** — Update documentation and developer journal.
+3. **Phase 9.3** — Profile-aware routing enhancements (optional).
+4. **Phase 9.4** — Profile support surfaced in MCP server.
+
+---
+
+## 9. Checklist
+
+- [ ] Dataclasses merged with type hints and docstrings.
+- [ ] Registry loads built-ins and user overrides.
+- [ ] Inheritance and validation scripts implemented.
+- [ ] Built-in profiles validated against catalog.
+- [ ] Tests added and passing locally.
+- [ ] Documentation updated; follow-up issues opened.
+
+---

--- a/stratifyai/profiles/models.py
+++ b/stratifyai/profiles/models.py
@@ -1,0 +1,270 @@
+"""Profile data models for StratifyAI.
+
+Profiles are reusable configuration bundles that standardize model behavior
+across providers. This module defines the data model and structural validation.
+
+Capability validation (e.g., checking ``supports_vision`` against catalog
+metadata) is handled by the registry, not here — keeping the data model
+decoupled from the catalog.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Literal, Optional
+
+
+@dataclass
+class ProfileParameter:
+    """Schema definition for a single profile parameter type.
+
+    There are exactly 8 of these, defined in :data:`PARAMETER_DEFINITIONS`.
+    Each describes what values a given parameter key accepts across all
+    profiles.
+
+    Attributes:
+        name: Parameter key (e.g., ``"temperature"``).
+        type: Value type for validation.
+        description: Human-readable description.
+        min_value: Minimum for number/integer types.
+        max_value: Maximum for number/integer types.
+        choices: Valid values for select type.
+        default: Default value when not specified in a profile.
+    """
+
+    name: str
+    type: Literal["number", "integer", "boolean", "string", "select"] = "string"
+    description: str = ""
+    min_value: Optional[float] = None
+    max_value: Optional[float] = None
+    choices: Optional[List[str]] = None
+    default: Any = None
+
+    def validate(self, value: Any) -> Any:
+        """Validate and coerce a parameter value against this schema.
+
+        Args:
+            value: The value to validate.
+
+        Returns:
+            The validated (and possibly coerced) value.
+
+        Raises:
+            ValueError: If the value fails validation.
+        """
+        if value is None:
+            return self.default
+
+        if self.type == "number":
+            try:
+                value = float(value)
+            except (TypeError, ValueError):
+                raise ValueError(
+                    f"Parameter '{self.name}' must be a number, got: {value!r}"
+                )
+            if self.min_value is not None and value < self.min_value:
+                raise ValueError(
+                    f"Parameter '{self.name}' must be >= {self.min_value}, "
+                    f"got: {value}"
+                )
+            if self.max_value is not None and value > self.max_value:
+                raise ValueError(
+                    f"Parameter '{self.name}' must be <= {self.max_value}, "
+                    f"got: {value}"
+                )
+
+        elif self.type == "integer":
+            try:
+                value = int(value)
+            except (TypeError, ValueError):
+                raise ValueError(
+                    f"Parameter '{self.name}' must be an integer, got: {value!r}"
+                )
+            if self.min_value is not None and value < self.min_value:
+                raise ValueError(
+                    f"Parameter '{self.name}' must be >= {int(self.min_value)}, "
+                    f"got: {value}"
+                )
+            if self.max_value is not None and value > self.max_value:
+                raise ValueError(
+                    f"Parameter '{self.name}' must be <= {int(self.max_value)}, "
+                    f"got: {value}"
+                )
+
+        elif self.type == "boolean":
+            if not isinstance(value, bool):
+                raise ValueError(
+                    f"Parameter '{self.name}' must be a boolean, got: {value!r}"
+                )
+
+        elif self.type == "select":
+            if self.choices and str(value) not in self.choices:
+                raise ValueError(
+                    f"Parameter '{self.name}' must be one of "
+                    f"{self.choices}, got: {value!r}"
+                )
+
+        return value
+
+
+# ---------------------------------------------------------------------------
+# Global parameter definitions — the fixed schema for all profiles
+# ---------------------------------------------------------------------------
+
+PARAMETER_DEFINITIONS: Dict[str, ProfileParameter] = {
+    "temperature": ProfileParameter(
+        name="temperature",
+        type="number",
+        description="Sampling temperature (0.0 = deterministic, 2.0 = creative)",
+        min_value=0.0,
+        max_value=2.0,
+        default=0.7,
+    ),
+    "max_tokens": ProfileParameter(
+        name="max_tokens",
+        type="integer",
+        description="Maximum tokens to generate in the response",
+        min_value=1,
+        max_value=1_000_000,
+        default=2048,
+    ),
+    "reasoning_depth": ProfileParameter(
+        name="reasoning_depth",
+        type="select",
+        description="Chain-of-thought reasoning depth (advisory)",
+        choices=["minimal", "standard", "deep"],
+        default="standard",
+    ),
+    "speed_vs_accuracy": ProfileParameter(
+        name="speed_vs_accuracy",
+        type="select",
+        description="Tradeoff preference — maps to router strategy hints",
+        choices=["speed", "balanced", "accuracy"],
+        default="balanced",
+    ),
+    "cost_sensitivity": ProfileParameter(
+        name="cost_sensitivity",
+        type="select",
+        description="Budget awareness — affects router model selection hints",
+        choices=["low", "medium", "high"],
+        default="medium",
+    ),
+    "multimodal": ProfileParameter(
+        name="multimodal",
+        type="boolean",
+        description="Require vision-enabled models when true",
+        default=False,
+    ),
+    "json_mode": ProfileParameter(
+        name="json_mode",
+        type="boolean",
+        description="Enforce strict JSON responses when supported",
+        default=False,
+    ),
+    "tool_use": ProfileParameter(
+        name="tool_use",
+        type="boolean",
+        description="Require models with function/tool calling support",
+        default=False,
+    ),
+}
+
+
+@dataclass
+class Profile:
+    """A named, reusable configuration bundle.
+
+    Profiles standardize model behavior across providers by encapsulating
+    common parameter sets. They can inherit from other profiles via the
+    ``extends`` field.
+
+    Attributes:
+        name: Unique profile identifier (lowercase).
+        description: Human-readable description.
+        parameters: Parameter values (keys must exist in
+            :data:`PARAMETER_DEFINITIONS`).
+        tags: Tags for categorization and filtering.
+        extends: Optional parent profile name for inheritance.
+        source: Whether this profile is built-in or user-defined.
+        notes: Optional freeform notes (author, usage context, etc.).
+    """
+
+    name: str
+    description: str = ""
+    parameters: Dict[str, Any] = field(default_factory=dict)
+    tags: List[str] = field(default_factory=list)
+    extends: Optional[str] = None
+    source: Literal["builtin", "user"] = "builtin"
+    notes: Optional[str] = None
+
+    def validate_parameters(self) -> None:
+        """Validate all parameter values against :data:`PARAMETER_DEFINITIONS`.
+
+        Checks that every key is a known parameter and that each value
+        passes the corresponding :class:`ProfileParameter` validation.
+        Unknown keys produce a warning-level message but do not raise.
+
+        Raises:
+            ValueError: If any parameter value fails structural validation.
+        """
+        import warnings
+
+        errors: List[str] = []
+
+        for key, value in self.parameters.items():
+            param_def = PARAMETER_DEFINITIONS.get(key)
+            if param_def is None:
+                warnings.warn(
+                    f"Unknown profile parameter '{key}' in profile "
+                    f"'{self.name}'. Known parameters: "
+                    f"{sorted(PARAMETER_DEFINITIONS.keys())}",
+                    stacklevel=2,
+                )
+                continue
+
+            try:
+                # Validate and coerce in-place
+                self.parameters[key] = param_def.validate(value)
+            except ValueError as exc:
+                errors.append(str(exc))
+
+        if errors:
+            raise ValueError(
+                f"Profile '{self.name}' has invalid parameters:\n"
+                + "\n".join(f"  - {e}" for e in errors)
+            )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the profile for API responses.
+
+        Returns:
+            A JSON-serializable dictionary with all profile metadata.
+        """
+        return {
+            "name": self.name,
+            "description": self.description,
+            "parameters": dict(self.parameters),
+            "tags": list(self.tags),
+            "extends": self.extends,
+            "source": self.source,
+            "notes": self.notes,
+        }
+
+
+def merge_parameters(
+    parent: Dict[str, Any],
+    child: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Merge parent and child profile parameters.
+
+    Child values override parent values. Used by the registry to resolve
+    ``extends`` inheritance chains.
+
+    Args:
+        parent: Parent profile's parameter dict.
+        child: Child profile's parameter dict (takes precedence).
+
+    Returns:
+        A new dict with merged parameters.
+    """
+    return {**parent, **child}


### PR DESCRIPTION
feat(core): add profile data model and parameter schema (Phase 9.0)

Implement the foundational data model for the StratifyAI profile system:

- ProfileParameter schema class with validation for 5 types (number,
  integer, boolean, string, select) including range/choice enforcement
- PARAMETER_DEFINITIONS constant with 8 profile parameters: temperature,
  max_tokens, reasoning_depth, speed_vs_accuracy, cost_sensitivity,
  multimodal, json_mode, tool_use
- Profile dataclass with structural validation, to_dict() serialization,
  and extends field for inheritance
- merge_parameters() utility for registry inheritance resolution
- GitHub issue tracking Phase 9.0 completion

Data model is intentionally decoupled from the catalog — no imports from
config or catalog_manager. Capability validation deferred to the registry
(Step 3).

Closes #1

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements foundational data model for StratifyAI profile system with `ProfileParameter` validation schema (5 types: number, integer, boolean, string, select) and `Profile` dataclass for configuration bundles. Adds tracking issue document for Phase 9.0 implementation roadmap.

**Key Changes:**
- Clean data model implementation with comprehensive type hints and docstrings following Google style
- Validation logic with range/choice enforcement and coercion for numeric types
- 8 predefined parameters: temperature, max_tokens, reasoning_depth, speed_vs_accuracy, cost_sensitivity, multimodal, json_mode, tool_use
- Intentionally decoupled from catalog (no imports), deferring capability validation to registry
- Structural foundation for inheritance via `extends` field and `merge_parameters()` utility

**Minor Issues:**
- Missing `__init__.py` in `stratifyai/profiles/` directory (needed for proper Python package structure)
- Minor formatting inconsistency in issue document

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- High-quality implementation with comprehensive validation logic, type hints, and documentation. Missing `__init__.py` is a minor structural issue that should be addressed before integration but doesn't affect functionality since the module isn't imported yet. Code follows project conventions and is well-tested conceptually (validation logic is sound). Deferred components (registry, YAML loader, tests) are acknowledged in PR description.
- No files require special attention - both files are clean with only minor style improvements needed

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| stratifyai/profiles/models.py | Clean data model implementation with comprehensive validation logic; missing `__init__.py` in parent directory prevents module import |
| github/ISSUES/phase-9.0-profile-data-model.md | Well-structured tracking document for Phase 9.0 implementation; minor formatting inconsistency |

</details>


</details>


<sub>Last reviewed commit: 9e10252</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->