### PR TITLE
PR - feat(PR 3): Cost and Validation implementation

### DIFF
--- a/developer/MCP-STATUS.md
+++ b/developer/MCP-STATUS.md
@@ -16,8 +16,8 @@ Project Board: https://github.com/users/Bytes0211/projects/4
 |---|---|---|---|---|---|
 | 0 | Contract Freeze | https://github.com/Bytes0211/stratifyai/issues/19 | Done | - | 2026-04-03 | Contract and plan docs finalized |
 | 1 | Bootstrap | https://github.com/Bytes0211/stratifyai/issues/20 | Done | - | 2026-04-03 | MCP server scaffold, entrypoint, schemas, and errors verified |
-| 2 | Core Tools | https://github.com/Bytes0211/stratifyai/issues/21 | Planned | - | 2026-04-03 | Phase field assigned in project |
-| 3 | Cost Tools | https://github.com/Bytes0211/stratifyai/issues/22 | Planned | - | 2026-04-03 | Phase field assigned in project |
+| 2 | Core Tools | https://github.com/Bytes0211/stratifyai/issues/21 | Done | - | 2026-04-03 | Core MCP execution and model lookup tools verified in tools.py |
+| 3 | Cost Tools | https://github.com/Bytes0211/stratifyai/issues/22 | Done | - | 2026-04-03 | Session cost tracking, summary filters, and validation tooling verified |
 | 4 | Resources | https://github.com/Bytes0211/stratifyai/issues/23 | Planned | - | 2026-04-03 | Phase field assigned in project |
 | 5 | Prompts | https://github.com/Bytes0211/stratifyai/issues/24 | Planned | - | 2026-04-03 | Phase field assigned in project |
 | 6 | HTTP Transport | https://github.com/Bytes0211/stratifyai/issues/25 | Planned | - | 2026-04-03 | Phase field assigned in project |
@@ -51,21 +51,21 @@ Use this section for fine-grained execution status. Update step status as work m
 
 | Step ID | Step | Status | Updated | Evidence |
 |---|---|---|---|---|
-| P2-S1 | Implement chat_completion tool with schema output | Planned | 2026-04-03 | Issue 21 |
-| P2-S2 | Implement chat_with_routing tool with route metadata | Planned | 2026-04-03 | Issue 21 |
-| P2-S3 | Implement list_providers and list_models tools | Planned | 2026-04-03 | Issue 21 |
-| P2-S4 | Implement get_model_info tool with catalog metadata | Planned | 2026-04-03 | Issue 21 |
-| P2-S5 | Validate structured errors for invalid provider/model | Planned | 2026-04-03 | Issue 21 |
+| P2-S1 | Implement chat_completion tool with schema output | Done | 2026-04-03 | stratifyai/mcp_server/tools.py |
+| P2-S2 | Implement chat_with_routing tool with route metadata | Done | 2026-04-03 | stratifyai/mcp_server/tools.py |
+| P2-S3 | Implement list_providers and list_models tools | Done | 2026-04-03 | stratifyai/mcp_server/tools.py |
+| P2-S4 | Implement get_model_info tool with catalog metadata | Done | 2026-04-03 | stratifyai/mcp_server/tools.py |
+| P2-S5 | Validate structured errors for invalid provider/model | Done | 2026-04-03 | tests/test_mcp_tools.py |
 
 ### Phase 3 - Cost and Validation Tools
 
 | Step ID | Step | Status | Updated | Evidence |
 |---|---|---|---|---|
-| P3-S1 | Add mcp session cost tracker wiring in tools module | Planned | 2026-04-03 | Issue 22 |
-| P3-S2 | Implement get_cost_summary tool and filters | Planned | 2026-04-03 | Issue 22 |
-| P3-S3 | Implement validate_provider tool | Planned | 2026-04-03 | Issue 22 |
-| P3-S4 | Implement estimate_cost tool using token counter | Planned | 2026-04-03 | Issue 22 |
-| P3-S5 | Verify cost totals update after chat tool calls | Planned | 2026-04-03 | Issue 22 |
+| P3-S1 | Add mcp session cost tracker wiring in tools module | Done | 2026-04-03 | stratifyai/mcp_server/tools.py |
+| P3-S2 | Implement get_cost_summary tool and filters | Done | 2026-04-03 | stratifyai/mcp_server/tools.py |
+| P3-S3 | Implement validate_provider tool | Done | 2026-04-03 | stratifyai/mcp_server/tools.py |
+| P3-S4 | Implement estimate_cost tool using token counter | Done | 2026-04-03 | stratifyai/mcp_server/tools.py |
+| P3-S5 | Verify cost totals update after chat tool calls | Done | 2026-04-03 | tests/test_mcp_tools.py |
 
 ### Phase 4 - Resources
 

--- a/stratifyai/mcp_server/tools.py
+++ b/stratifyai/mcp_server/tools.py
@@ -32,6 +32,51 @@ from .schemas import (
 _mcp_cost_tracker = CostTracker()
 
 
+def _track_response_cost(response: Any) -> None:
+    """Record response usage in the shared MCP session tracker."""
+    usage = response.usage
+    _mcp_cost_tracker.add_entry(
+        provider=response.provider,
+        model=response.model,
+        prompt_tokens=usage.prompt_tokens,
+        completion_tokens=usage.completion_tokens,
+        total_tokens=usage.total_tokens,
+        cost_usd=usage.cost_usd,
+        request_id=response.id,
+        cached_tokens=usage.cached_tokens,
+        cache_creation_tokens=usage.cache_creation_tokens,
+        cache_read_tokens=usage.cache_read_tokens,
+    )
+
+
+def _build_cost_summary(
+    provider: str | None = None,
+    model: str | None = None,
+) -> CostSummaryOutput:
+    """Build a filtered cost summary from tracked MCP session entries."""
+    entries = _mcp_cost_tracker.get_entries(provider=provider, model=model)
+
+    total_cost_usd = sum(entry.cost_usd for entry in entries)
+    total_tokens = sum(entry.total_tokens for entry in entries)
+    total_calls = len(entries)
+
+    by_provider: dict[str, float] = {}
+    by_model: dict[str, float] = {}
+    for entry in entries:
+        by_provider[entry.provider] = (
+            by_provider.get(entry.provider, 0.0) + entry.cost_usd
+        )
+        by_model[entry.model] = by_model.get(entry.model, 0.0) + entry.cost_usd
+
+    return CostSummaryOutput(
+        total_cost_usd=total_cost_usd,
+        total_calls=total_calls,
+        total_tokens=total_tokens,
+        by_provider=by_provider,
+        by_model=by_model,
+    )
+
+
 def _is_configured(provider: str) -> bool:
     """Check if a provider has an API key configured."""
     env_key = APIKeyHelper.PROVIDER_ENV_KEYS.get(provider)
@@ -83,6 +128,7 @@ def register(mcp: FastMCP) -> None:  # noqa: C901
                 max_tokens=max_tokens,
             )
             response = await client.chat_completion(request)
+            _track_response_cost(response)
 
             cost = 0.0
             if response.usage and response.usage.cost_usd is not None:
@@ -142,6 +188,7 @@ def register(mcp: FastMCP) -> None:  # noqa: C901
                 temperature=0.7,
             )
             response = await client.chat_completion(request)
+            _track_response_cost(response)
 
             cost = 0.0
             if response.usage and response.usage.cost_usd is not None:
@@ -248,14 +295,7 @@ def register(mcp: FastMCP) -> None:  # noqa: C901
         Optionally filter by provider or model.
         """
         try:
-            summary = _mcp_cost_tracker.get_summary()
-            output = CostSummaryOutput(
-                total_cost_usd=float(summary.get("total_cost_usd", 0.0)),
-                total_calls=int(summary.get("total_calls", 0)),
-                total_tokens=int(summary.get("total_tokens", 0)),
-                by_provider=summary.get("by_provider", {}),
-                by_model=summary.get("by_model", {}),
-            )
+            output = _build_cost_summary(provider=provider, model=model)
             return dict(output.model_dump())
         except Exception as exc:
             raise_tool_error(exc, provider, model)
@@ -265,6 +305,18 @@ def register(mcp: FastMCP) -> None:  # noqa: C901
     async def validate_provider(provider: str) -> dict[str, Any]:
         """Validate that a provider is configured and accessible."""
         try:
+            if provider not in MODEL_CATALOG:
+                output = ValidateProviderOutput(
+                    provider=provider,
+                    configured=False,
+                    models_available=[],
+                    validation_errors=[
+                        f"Unknown provider: {provider}",
+                        f"No models found in catalog for provider '{provider}'",
+                    ],
+                )
+                return dict(output.model_dump())
+
             configured = _is_configured(provider)
             models = list(MODEL_CATALOG.get(provider, {}).keys())
             errors: list[str] = []

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,10 +1,23 @@
 """Tests for MCP tools — uses mocked LLMClient/Router."""
 
 import json
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
+from stratifyai.mcp_server import tools as mcp_tools
 from stratifyai.mcp_server.server import mcp
+from stratifyai.models import ChatResponse, Usage
+
+
+@pytest.fixture(autouse=True)
+def reset_mcp_cost_tracker():
+    """Reset the shared MCP cost tracker between tests."""
+    mcp_tools._mcp_cost_tracker.reset()
+    yield
+    mcp_tools._mcp_cost_tracker.reset()
 
 
 def _get_tool(name: str):
@@ -149,6 +162,78 @@ class TestGetCostSummary:
         assert result["mcp_schema_version"] == 1
         assert isinstance(result["total_cost_usd"], float)
         assert isinstance(result["total_calls"], int)
+
+    @pytest.mark.asyncio
+    async def test_summary_updates_after_chat_completion(self, monkeypatch):
+        mock_response = ChatResponse(
+            id="req-123",
+            model="gpt-4.1-mini",
+            content="Hello back",
+            finish_reason="stop",
+            usage=Usage(
+                prompt_tokens=10,
+                completion_tokens=5,
+                total_tokens=15,
+                cost_usd=0.0015,
+            ),
+            provider="openai",
+            created_at=datetime.now(),
+            raw_response={},
+            latency_ms=12.0,
+        )
+        mock_client = SimpleNamespace(
+            chat_completion=AsyncMock(return_value=mock_response)
+        )
+
+        monkeypatch.setattr(mcp_tools, "LLMClient", lambda provider: mock_client)
+
+        await _get_tool("chat_completion")(
+            provider="openai",
+            model="gpt-4.1-mini",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+        summary = await _get_tool("get_cost_summary")()
+        assert summary["total_calls"] == 1
+        assert summary["total_tokens"] == 15
+        assert summary["total_cost_usd"] == pytest.approx(0.0015)
+        assert summary["by_provider"]["openai"] == pytest.approx(0.0015)
+        assert summary["by_model"]["gpt-4.1-mini"] == pytest.approx(0.0015)
+
+    @pytest.mark.asyncio
+    async def test_summary_filters_by_provider_and_model(self):
+        mcp_tools._mcp_cost_tracker.add_entry(
+            provider="openai",
+            model="gpt-4.1-mini",
+            prompt_tokens=10,
+            completion_tokens=5,
+            total_tokens=15,
+            cost_usd=0.0015,
+            request_id="req-1",
+        )
+        mcp_tools._mcp_cost_tracker.add_entry(
+            provider="anthropic",
+            model="claude-3-5-haiku-20241022",
+            prompt_tokens=20,
+            completion_tokens=10,
+            total_tokens=30,
+            cost_usd=0.003,
+            request_id="req-2",
+        )
+
+        openai_summary = await _get_tool("get_cost_summary")(provider="openai")
+        assert openai_summary["total_calls"] == 1
+        assert openai_summary["total_tokens"] == 15
+        assert openai_summary["by_provider"] == {"openai": pytest.approx(0.0015)}
+
+        model_summary = await _get_tool("get_cost_summary")(
+            model="claude-3-5-haiku-20241022"
+        )
+        assert model_summary["total_calls"] == 1
+        assert model_summary["total_tokens"] == 30
+        assert model_summary["by_model"] == {
+            "claude-3-5-haiku-20241022": pytest.approx(0.003)
+        }
 
 
 class TestToolRegistration:


### PR DESCRIPTION
feat(PR 3): Cost and Validation implementation

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements Phase 2 (Core Tools) and Phase 3 (Cost and Validation) of the MCP server, adding cost tracking wiring into the chat tools, a filtered `get_cost_summary` helper, early-exit validation in `validate_provider` for unknown providers, and an `estimate_cost` tool. The changes integrate cleanly with the existing `CostTracker` and schema layer.

**Key changes:**
- `_track_response_cost`: new helper that records every chat response into the module-level `CostTracker`; called after each `chat_completion` and `chat_with_routing` response
- `_build_cost_summary`: replaces the previous `get_summary()`-based approach with a filtered `get_entries()` query, enabling per-provider and per-model breakdowns
- `validate_provider`: now returns early with a structured error when the provider is not in `MODEL_CATALOG`, rather than relying solely on API-key checks
- `tests/test_mcp_tools.py`: adds an `autouse` fixture to reset the shared tracker between tests, plus coverage for cost accumulation and summary filtering

**Issues found:**
- `_track_response_cost` dereferences `response.usage` without checking for `None`, even though both call sites have pre-existing `if response.usage:` guards immediately after the call — a `None` usage object from any provider would turn a successful API call into a tool-level error
- `MODEL_CATALOG.get(provider, {})` in `validate_provider` uses an unreachable `{}` default after the `provider not in MODEL_CATALOG` early-exit guard

<h3>Confidence Score: 3/5</h3>

Safe to merge after addressing the missing `response.usage` None guard in `_track_response_cost`.

The overall structure is solid and the tests are well-written with proper tracker isolation. The P1 issue — `_track_response_cost` accessing `response.usage` attributes without a None check while the surrounding code explicitly guards for this — could turn a successful API call into a tool error in real-world scenarios where a provider returns no usage data. A one-line fix resolves it. The P2 redundant default is cosmetic.

`stratifyai/mcp_server/tools.py` — specifically the `_track_response_cost` function (lines 35–49)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| stratifyai/mcp_server/tools.py | Adds cost tracking integration, `_track_response_cost` helper, `_build_cost_summary` with filter support, and validates unknown providers early in `validate_provider`. Key issue: `_track_response_cost` doesn't guard against `response.usage is None`, which the surrounding call-site code explicitly does. |
| tests/test_mcp_tools.py | Adds an `autouse` fixture to reset the shared cost tracker between tests, plus three new test cases covering cost accumulation after chat completion, per-provider/model summary filtering, and unknown-provider validation. Tests are well-structured and use appropriate mocking. |
| developer/MCP-STATUS.md | Status tracking document updated to mark Phase 2 and Phase 3 steps as Done with evidence pointing to the relevant source files. No code concerns. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: stratifyai/mcp_server/tools.py
Line: 35-49

Comment:
**`response.usage` accessed without a None guard**

`_track_response_cost` unconditionally dereferences `response.usage` on line 37, but both call sites in `chat_completion` (line 134) and `chat_with_routing` (line 194) have explicit `if response.usage:` guards *after* this call. This inconsistency means that if any provider returns a `ChatResponse` where `usage` is `None` at runtime — which the pre-existing defensive guards clearly anticipate — the function will crash with an `AttributeError` before the guard is ever reached.

The crash happens inside the tool's `try/except`, so it won't be silently swallowed, but it will surface as a tool-level error for an otherwise-successful chat completion, and cost tracking will be skipped.

A guard at the top of `_track_response_cost` (e.g., `if response.usage is None: return`) would make it consistent with the rest of the code and prevent a successful API call from being reported as a failure.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: stratifyai/mcp_server/tools.py
Line: 321

Comment:
**Unreachable default in `MODEL_CATALOG.get`**

After the early-exit guard `if provider not in MODEL_CATALOG` on line 308, the `{}` default in `MODEL_CATALOG.get(provider, {})` on line 321 can never be reached — `provider` is guaranteed to be a key in `MODEL_CATALOG` at this point. Using a direct `MODEL_CATALOG[provider].keys()` would be clearer and avoid the misleading fallback:

```suggestion
            models = list(MODEL_CATALOG[provider].keys())
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(PR 3): Cost and Validation implemen..."](https://github.com/bytes0211/stratifyai/commit/bc36d477ce14591c74dd5d30afa47b7ae0b61e42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27300529)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->