### PR TITLE
PR - [MCP Phase 4] Resource Layer

### DIFF
--- a/developer/MCP-STATUS.md
+++ b/developer/MCP-STATUS.md
@@ -18,7 +18,7 @@ Project Board: https://github.com/users/Bytes0211/projects/4
 | 1 | Bootstrap | https://github.com/Bytes0211/stratifyai/issues/20 | Done | - | 2026-04-03 | MCP server scaffold, entrypoint, schemas, and errors verified |
 | 2 | Core Tools | https://github.com/Bytes0211/stratifyai/issues/21 | Done | - | 2026-04-03 | Core MCP execution and model lookup tools verified in tools.py |
 | 3 | Cost Tools | https://github.com/Bytes0211/stratifyai/issues/22 | Done | - | 2026-04-03 | Session cost tracking, summary filters, and validation tooling verified |
-| 4 | Resources | https://github.com/Bytes0211/stratifyai/issues/23 | Planned | - | 2026-04-03 | Phase field assigned in project |
+| 4 | Resources | https://github.com/Bytes0211/stratifyai/issues/23 | Done | - | 2026-04-03 | MCP resources verified with focused resource test coverage |
 | 5 | Prompts | https://github.com/Bytes0211/stratifyai/issues/24 | Planned | - | 2026-04-03 | Phase field assigned in project |
 | 6 | HTTP Transport | https://github.com/Bytes0211/stratifyai/issues/25 | Planned | - | 2026-04-03 | Phase field assigned in project |
 | 7 | Tests and CI | https://github.com/Bytes0211/stratifyai/issues/26 | Planned | - | 2026-04-03 | Phase field assigned in project |
@@ -71,11 +71,11 @@ Use this section for fine-grained execution status. Update step status as work m
 
 | Step ID | Step | Status | Updated | Evidence |
 |---|---|---|---|---|
-| P4-S1 | Implement stratifyai://catalog resource | Planned | 2026-04-03 | Issue 23 |
-| P4-S2 | Implement stratifyai://catalog/{provider} resource | Planned | 2026-04-03 | Issue 23 |
-| P4-S3 | Implement providers and costs resources | Planned | 2026-04-03 | Issue 23 |
-| P4-S4 | Implement router strategies resource | Planned | 2026-04-03 | Issue 23 |
-| P4-S5 | Validate structured errors for unknown provider resource | Planned | 2026-04-03 | Issue 23 |
+| P4-S1 | Implement stratifyai://catalog resource | Done | 2026-04-03 | stratifyai/mcp_server/resources.py |
+| P4-S2 | Implement stratifyai://catalog/{provider} resource | Done | 2026-04-03 | stratifyai/mcp_server/resources.py |
+| P4-S3 | Implement providers and costs resources | Done | 2026-04-03 | stratifyai/mcp_server/resources.py |
+| P4-S4 | Implement router strategies resource | Done | 2026-04-03 | stratifyai/mcp_server/resources.py |
+| P4-S5 | Validate structured errors for unknown provider resource | Done | 2026-04-03 | tests/test_mcp_resources.py |
 
 ### Phase 5 - Prompt Exposure
 

--- a/stratifyai/mcp_server/resources.py
+++ b/stratifyai/mcp_server/resources.py
@@ -51,10 +51,10 @@ def register(mcp: FastMCP) -> None:
     @mcp.resource("stratifyai://costs")
     async def costs_resource() -> str:
         """Current session cost summary."""
-        from stratifyai.mcp_server.tools import _mcp_cost_tracker
+        from stratifyai.mcp_server.tools import _build_cost_summary
 
-        summary = _mcp_cost_tracker.get_summary()
-        return json.dumps(summary, indent=2)
+        summary = _build_cost_summary()
+        return json.dumps(summary.model_dump(), indent=2)
 
     @mcp.resource("stratifyai://router/strategies")
     async def router_strategies_resource() -> str:

--- a/tests/test_mcp_resources.py
+++ b/tests/test_mcp_resources.py
@@ -1,10 +1,20 @@
 """Tests for MCP resources."""
 
 import json
+from pathlib import Path
 
 import pytest
 
+from stratifyai.mcp_server import tools as mcp_tools
 from stratifyai.mcp_server.server import mcp
+
+
+@pytest.fixture(autouse=True)
+def reset_mcp_cost_tracker():
+    """Reset the shared MCP cost tracker between tests."""
+    mcp_tools._mcp_cost_tracker.reset()
+    yield
+    mcp_tools._mcp_cost_tracker.reset()
 
 
 def _get_resource(uri: str):
@@ -23,6 +33,8 @@ class TestCatalogResource:
         result = await fn()
         data = json.loads(result)
         assert "providers" in data
+        assert "version" in data
+        assert "updated" in data
 
     @pytest.mark.asyncio
     async def test_contains_known_providers(self):
@@ -33,6 +45,18 @@ class TestCatalogResource:
         assert "openai" in providers
         assert "anthropic" in providers
 
+    @pytest.mark.asyncio
+    async def test_matches_expected_top_level_schema_shape(self):
+        fn = _get_resource("stratifyai://catalog")
+        result = await fn()
+        data = json.loads(result)
+
+        schema_path = Path(__file__).resolve().parent.parent / "catalog" / "schema.json"
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+        assert data.keys() >= set(schema["required"])
+        assert isinstance(data["providers"], dict)
+
 
 class TestCatalogProviderResource:
     @pytest.mark.asyncio
@@ -42,6 +66,15 @@ class TestCatalogProviderResource:
         data = json.loads(result)
         assert isinstance(data, dict)
         assert len(data) > 0
+
+    @pytest.mark.asyncio
+    async def test_returns_only_requested_provider_models(self):
+        fn = _get_resource("stratifyai://catalog/{provider}")
+        result = await fn(provider="openai")
+        data = json.loads(result)
+
+        assert "gpt-4.1-mini" in data
+        assert not any(model_id.startswith("claude") for model_id in data)
 
     @pytest.mark.asyncio
     async def test_invalid_provider_raises(self):
@@ -71,6 +104,29 @@ class TestCostsResource:
         result = await fn()
         data = json.loads(result)
         assert isinstance(data, dict)
+
+    @pytest.mark.asyncio
+    async def test_returns_mcp_cost_summary_shape(self):
+        mcp_tools._mcp_cost_tracker.add_entry(
+            provider="openai",
+            model="gpt-4.1-mini",
+            prompt_tokens=10,
+            completion_tokens=5,
+            total_tokens=15,
+            cost_usd=0.0015,
+            request_id="req-1",
+        )
+
+        fn = _get_resource("stratifyai://costs")
+        result = await fn()
+        data = json.loads(result)
+
+        assert data["mcp_schema_version"] == 1
+        assert data["total_cost_usd"] == pytest.approx(0.0015)
+        assert data["total_calls"] == 1
+        assert data["total_tokens"] == 15
+        assert data["by_provider"] == {"openai": pytest.approx(0.0015)}
+        assert data["by_model"] == {"gpt-4.1-mini": pytest.approx(0.0015)}
 
 
 class TestRouterStrategiesResource:


### PR DESCRIPTION
feat(PR 41 - MCP Phase 4): implement phase 4 - Resources

Closes #23

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes MCP Phase 4 by fixing the `costs_resource` to use the structured `_build_cost_summary()` helper (returning a `CostSummaryOutput` Pydantic model with consistent field names and `mcp_schema_version`) instead of the raw `CostTracker.get_summary()` whose keys were incompatible with the schema. Three new tests are added: catalog top-level schema shape, provider-scoped model isolation, and full `CostSummaryOutput` field assertions — all guarded by a new `autouse` cost-tracker reset fixture.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are narrowly scoped, the fix is correct, and new tests validate the repaired behaviour.

No P0/P1 issues found. The code change is a straightforward, correct switch from an incompatible dict to a structured Pydantic model. Tests are well-isolated and the model ID asserted in tests (`gpt-4.1-mini`) is confirmed to exist in the catalog.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| stratifyai/mcp_server/resources.py | Switches `costs_resource` from the raw `CostTracker.get_summary()` (which uses different key names) to `_build_cost_summary()`, correctly serialising the structured `CostSummaryOutput` Pydantic model including `mcp_schema_version`. |
| tests/test_mcp_resources.py | Adds an autouse fixture for cost-tracker isolation, and three targeted tests: catalog schema shape, provider-scoped model filtering, and the full `CostSummaryOutput` field shape. All look correct given the supporting code. |
| developer/MCP-STATUS.md | Status entries for Phase 4 steps updated from Planned → Done with file-level evidence links. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(PR 41 - MCP Phase 4): implement pha..."](https://github.com/bytes0211/stratifyai/commit/a05f7cd910694253518aab7f91f338264822786f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27301847)</sub>

<!-- /greptile_comment -->