### PR TITLE
PR - [MCP Phase 5] Prompt Exposure

### DIFF
--- a/developer/MCP-STATUS.md
+++ b/developer/MCP-STATUS.md
@@ -19,7 +19,7 @@ Project Board: https://github.com/users/Bytes0211/projects/4
 | 2 | Core Tools | https://github.com/Bytes0211/stratifyai/issues/21 | Done | - | 2026-04-03 | Core MCP execution and model lookup tools verified in tools.py |
 | 3 | Cost Tools | https://github.com/Bytes0211/stratifyai/issues/22 | Done | - | 2026-04-03 | Session cost tracking, summary filters, and validation tooling verified |
 | 4 | Resources | https://github.com/Bytes0211/stratifyai/issues/23 | Done | - | 2026-04-03 | MCP resources verified with focused resource test coverage |
-| 5 | Prompts | https://github.com/Bytes0211/stratifyai/issues/24 | Planned | - | 2026-04-03 | Phase field assigned in project |
+| 5 | Prompts | https://github.com/Bytes0211/stratifyai/issues/24 | Done | - | 2026-04-03 | Named and dynamic MCP prompts verified with prompt test coverage |
 | 6 | HTTP Transport | https://github.com/Bytes0211/stratifyai/issues/25 | Planned | - | 2026-04-03 | Phase field assigned in project |
 | 7 | Tests and CI | https://github.com/Bytes0211/stratifyai/issues/26 | Planned | - | 2026-04-03 | Phase field assigned in project |
 | 8 | Docs and Config | https://github.com/Bytes0211/stratifyai/issues/27 | Planned | - | 2026-04-03 | Phase field assigned in project |
@@ -81,11 +81,11 @@ Use this section for fine-grained execution status. Update step status as work m
 
 | Step ID | Step | Status | Updated | Evidence |
 |---|---|---|---|---|
-| P5-S1 | Register compare_models prompt | Planned | 2026-04-03 | Issue 24 |
-| P5-S2 | Register recommend_model prompt | Planned | 2026-04-03 | Issue 24 |
-| P5-S3 | Register analyze_costs prompt | Planned | 2026-04-03 | Issue 24 |
-| P5-S4 | Expose dynamic registry templates as prompts | Planned | 2026-04-03 | Issue 24 |
-| P5-S5 | Validate prompt output shape (role/content list) | Planned | 2026-04-03 | Issue 24 |
+| P5-S1 | Register compare_models prompt | Done | 2026-04-03 | stratifyai/mcp_server/prompts.py |
+| P5-S2 | Register recommend_model prompt | Done | 2026-04-03 | stratifyai/mcp_server/prompts.py |
+| P5-S3 | Register analyze_costs prompt | Done | 2026-04-03 | stratifyai/mcp_server/prompts.py |
+| P5-S4 | Expose dynamic registry templates as prompts | Done | 2026-04-03 | stratifyai/mcp_server/prompts.py |
+| P5-S5 | Validate prompt output shape (role/content list) | Done | 2026-04-03 | tests/test_mcp_prompts.py |
 
 ### Phase 6 - HTTP Transport (Optional, Post-GA)
 

--- a/stratifyai/mcp_server/prompts.py
+++ b/stratifyai/mcp_server/prompts.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from mcp.server.fastmcp import FastMCP
 
 from stratifyai.prompts import registry
@@ -15,28 +17,43 @@ def register(mcp: FastMCP) -> None:
     # ------------------------------------------------------------------
 
     @mcp.prompt()
-    def compare_models(models: str) -> str:
+    def compare_models(models: list[str] | str) -> list[dict[str, str]]:
         """Compare multiple LLM models side by side.
 
         Args:
-            models: Comma-separated list of provider/model pairs
-                    (e.g. "openai/gpt-4.1,anthropic/claude-sonnet-4-5")
+            models: List (or comma-separated string) of provider/model pairs
+                    (e.g. ["openai/gpt-4.1", "anthropic/claude-sonnet-4-5"])
         """
-        model_list = [m.strip() for m in models.split(",")]
+        if isinstance(models, str):
+            model_list = [m.strip() for m in models.split(",") if m.strip()]
+        else:
+            model_list = [m.strip() for m in models if m.strip()]
         formatted = "\n".join(f"- {m}" for m in model_list)
-        return (
-            f"Compare the following LLM models across key dimensions "
-            f"(capabilities, pricing, context window, speed, quality):\n\n{formatted}\n\n"
-            f"Provide a structured comparison table and recommend which model "
-            f"is best for different use cases."
-        )
+        return [
+            {
+                "role": "system",
+                "content": (
+                    "You are an expert model selection assistant. Compare models "
+                    "objectively across capability, cost, context window, speed, "
+                    "and output quality."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    "Compare the following models and provide a structured summary:\n\n"
+                    f"{formatted}\n\n"
+                    "Include tradeoffs and recommendations for common use cases."
+                ),
+            },
+        ]
 
     @mcp.prompt()
     def recommend_model(
         task_description: str,
         budget: str | None = None,
         priority: str | None = None,
-    ) -> str:
+    ) -> list[dict[str, str]]:
         """Recommend the best LLM model for a specific task.
 
         Args:
@@ -44,69 +61,78 @@ def register(mcp: FastMCP) -> None:
             budget: Optional budget constraint (e.g. "low", "$0.01 per request")
             priority: Optional priority — cost, quality, or latency
         """
-        parts = [
-            f"Recommend the best LLM model for the following task:\n\n{task_description}"
-        ]
+        parts = [f"Task:\n{task_description}"]
         if budget:
-            parts.append(f"\nBudget constraint: {budget}")
+            parts.append(f"Budget constraint: {budget}")
         if priority:
-            parts.append(f"\nPriority: {priority}")
-        parts.append(
-            "\n\nConsider the available providers (OpenAI, Anthropic, Google, DeepSeek, "
-            "Groq, Grok, OpenRouter, Ollama, Bedrock) and their models. "
-            "Explain your reasoning."
-        )
-        return "\n".join(parts)
+            parts.append(f"Priority: {priority}")
+        parts.append("Provide the top recommendation and one lower-cost fallback.")
+
+        return [
+            {
+                "role": "system",
+                "content": (
+                    "You are a routing and cost-aware model advisor for StratifyAI."
+                ),
+            },
+            {
+                "role": "user",
+                "content": "\n".join(parts),
+            },
+        ]
 
     @mcp.prompt()
-    def analyze_costs(time_period: str | None = None) -> str:
+    def analyze_costs(time_period: str | None = None) -> list[dict[str, str]]:
         """Generate a cost analysis prompt for the current session.
 
         Args:
             time_period: Optional time period filter (e.g. "last hour", "today")
         """
-        prompt = "Analyze the LLM usage costs for the current session."
+        prompt = "Analyze LLM usage costs for the current session."
         if time_period:
             prompt += f" Focus on the period: {time_period}."
         prompt += (
-            "\n\nUse the `get_cost_summary` tool to retrieve current cost data, "
-            "then provide:\n"
-            "1. Total spend breakdown by provider and model\n"
-            "2. Cost per request average\n"
-            "3. Recommendations for cost optimization"
+            "\n\nUse the get_cost_summary tool, then provide:\n"
+            "1. Spend breakdown by provider and model\n"
+            "2. Cost per request estimate\n"
+            "3. Actionable optimization recommendations"
         )
-        return prompt
+        return [
+            {
+                "role": "system",
+                "content": "You are a cost optimization analyst for LLM workloads.",
+            },
+            {"role": "user", "content": prompt},
+        ]
 
     # ------------------------------------------------------------------
     # Dynamic prompts from registry templates
     # ------------------------------------------------------------------
 
     for template in registry.list():
-        _register_template_prompt(mcp, template)
+        _register_template_prompt(mcp, template.name, template.description)
 
 
-def _register_template_prompt(mcp: FastMCP, template: object) -> None:
+def _register_template_prompt(
+    mcp: FastMCP,
+    template_name: str,
+    description: str,
+) -> None:
     """Register a single prompt template from the registry as an MCP prompt."""
-    name = getattr(template, "name", "")
-    description = getattr(template, "description", "")
-    system_template = getattr(template, "system", "")
-    user_template = getattr(template, "user", "")
 
-    @mcp.prompt(name=f"template_{name}", description=description)
-    def template_prompt(**kwargs: str) -> list[dict[str, str]]:
-        messages: list[dict[str, str]] = []
-        if system_template:
-            try:
-                messages.append(
-                    {"role": "system", "content": system_template.format(**kwargs)}
-                )
-            except KeyError:
-                messages.append({"role": "system", "content": system_template})
-        if user_template:
-            try:
-                messages.append(
-                    {"role": "user", "content": user_template.format(**kwargs)}
-                )
-            except KeyError:
-                messages.append({"role": "user", "content": user_template})
-        return messages
+    @mcp.prompt(name=template_name, description=description)
+    def template_prompt(**kwargs: Any) -> list[dict[str, str]]:
+        template = registry.get(template_name)
+
+        # Provide placeholder values for missing required parameters so prompts
+        # remain discoverable/callable even without explicit args.
+        params = {param.name: kwargs.get(param.name) for param in template.parameters}
+        for param in template.parameters:
+            if params[param.name] is None:
+                if param.default is not None:
+                    params[param.name] = param.default
+                elif param.required:
+                    params[param.name] = f"<{param.name}>"
+
+        rendered = template.render(**params)
+        return [{"role": msg.role, "content": msg.content} for msg in rendered]

--- a/tests/test_mcp_prompts.py
+++ b/tests/test_mcp_prompts.py
@@ -9,69 +9,69 @@ def _get_prompt(name: str):
 
 
 class TestNamedPrompts:
-    def test_compare_models_returns_string(self):
+    def test_compare_models_returns_messages(self):
         result = _get_prompt("compare_models")(
             models="openai/gpt-4.1,anthropic/claude-sonnet-4-5"
         )
-        assert isinstance(result, str)
-        assert "openai/gpt-4.1" in result
-        assert "anthropic/claude-sonnet-4-5" in result
-        assert "Compare" in result
+        assert isinstance(result, list)
+        assert result[0]["role"] == "system"
+        assert result[1]["role"] == "user"
+        assert "openai/gpt-4.1" in result[1]["content"]
+        assert "anthropic/claude-sonnet-4-5" in result[1]["content"]
 
     def test_recommend_model_basic(self):
         result = _get_prompt("recommend_model")(
             task_description="Summarize a 10-page legal document"
         )
-        assert isinstance(result, str)
-        assert "Summarize" in result
+        assert isinstance(result, list)
+        assert result[0]["role"] == "system"
+        assert result[1]["role"] == "user"
+        assert "Summarize" in result[1]["content"]
 
     def test_recommend_model_with_budget(self):
         result = _get_prompt("recommend_model")(
             task_description="Code review", budget="low"
         )
-        assert "budget" in result.lower() or "Budget" in result
+        assert "budget" in result[1]["content"].lower()
 
     def test_recommend_model_with_priority(self):
         result = _get_prompt("recommend_model")(
             task_description="Chat", priority="cost"
         )
-        assert "cost" in result.lower() or "Priority" in result
+        assert "priority" in result[1]["content"].lower()
+        assert "cost" in result[1]["content"].lower()
 
     def test_analyze_costs_basic(self):
         result = _get_prompt("analyze_costs")()
-        assert isinstance(result, str)
-        assert "cost" in result.lower()
+        assert isinstance(result, list)
+        assert "cost" in result[1]["content"].lower()
 
     def test_analyze_costs_with_period(self):
         result = _get_prompt("analyze_costs")(time_period="last hour")
-        assert "last hour" in result
+        assert "last hour" in result[1]["content"]
 
 
 class TestDynamicTemplatePrompts:
     def test_template_prompts_registered(self):
         registered = list(mcp._prompt_manager._prompts.keys())
-        template_prompts = [n for n in registered if n.startswith("template_")]
-        assert len(template_prompts) >= 5  # at least some built-in templates
+        named_prompts = {"compare_models", "recommend_model", "analyze_costs"}
+        dynamic_prompts = [n for n in registered if n not in named_prompts]
+        assert len(dynamic_prompts) >= 10
 
     def test_template_prompt_returns_messages(self):
-        # Find any template prompt
-        registered = list(mcp._prompt_manager._prompts.keys())
-        template_names = [n for n in registered if n.startswith("template_")]
-        assert len(template_names) > 0
-
-        # Call the first template prompt
-        fn = _get_prompt(template_names[0])
+        fn = _get_prompt("code_review")
         result = fn()
         assert isinstance(result, list)
+        assert len(result) >= 1
         for msg in result:
             assert "role" in msg
             assert "content" in msg
 
     def test_code_review_template_exists(self):
-        assert "template_code_review" in mcp._prompt_manager._prompts
+        assert "code_review" in mcp._prompt_manager._prompts
 
     def test_summarize_template_exists(self):
-        assert "template_summarize" in mcp._prompt_manager._prompts
+        assert "summarize" in mcp._prompt_manager._prompts
 
 
 class TestPromptRegistration:


### PR DESCRIPTION
feat(PR Prompt Exposure): implement phase 05 prompt exposure

Closes #24

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes MCP Phase 5 by converting all named prompts (`compare_models`, `recommend_model`, `analyze_costs`) to return MCP-spec-compliant `list[dict[str, str]]` message arrays, and refactors `_register_template_prompt` to accept `template_name`/`description` strings (re-fetching the template inside the closure) while dropping the `"template_"` prefix from dynamic prompt names. Tests are updated throughout to match the new return shape and name scheme.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both P2 findings are latent/speculative and do not affect any current template or prompt invocation.

All current built-in templates have either no required params or required params of type string/text, so the placeholder injection issue does not trigger today. The union-type annotation on compare_models is a schema-clarity concern but not a runtime failure. No P0/P1 issues were found.

stratifyai/mcp_server/prompts.py — the _register_template_prompt placeholder logic and the list[str] | str annotation on compare_models are worth revisiting as the template library grows.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| stratifyai/mcp_server/prompts.py | Converts named prompts to return MCP-compatible message lists; refactors _register_template_prompt to accept name/description and re-fetch template in closure; removes "template_" prefix from dynamic prompt names. Contains a latent issue where placeholder injection for required params will fail validate() for "number" or "choice" type params. |
| tests/test_mcp_prompts.py | Tests updated to match new list[dict] return shape; renamed template prompt lookups drop the "template_" prefix; dynamic prompt count assertion raised to ≥10. Well-aligned with the implementation changes. |
| developer/MCP-STATUS.md | Status tracking doc updated: Phase 5 steps marked Done with source-file pointers. No code impact. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: stratifyai/mcp_server/prompts.py
Line: 128-135

Comment:
**Placeholder injection breaks `number` and `choice` type required params**

The fallback `f"<{param.name}>"` is passed straight into `template.render()`, which calls `param.validate()`. For a `"number"` type param, `float("<param_name>")` raises `ValueError`; for a `"choice"` type param, the placeholder string won't appear in `choices` and also raises `ValueError`. No current built-in template has a required param of these types, but any future template that does will make its MCP prompt unconditionally fail when called without arguments — the opposite of the discoverability goal stated in the comment.

Consider skipping the `validate` path for placeholder-injected values, or restricting injection to `string`/`text` type params only.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: stratifyai/mcp_server/prompts.py
Line: 20

Comment:
**Union type annotation may produce an ambiguous JSON schema for FastMCP**

`list[str] | str` is a union that FastMCP must resolve when generating the MCP prompt's parameter schema. Depending on the FastMCP version, this may emit an `anyOf` schema that some MCP clients struggle with, or it may fall back to `string` only — silently dropping list support. Accepting only `str` (comma-separated, documented) or only `list[str]` would be unambiguous.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(PR Prompt Exposure): implement phas..."](https://github.com/bytes0211/stratifyai/commit/2087318be09ae72f99cd661953437c7fbfe79e8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27303120)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->