### PR TITLE
PR - [CE-2] Tool Registry & Namespacing

### DIFF
--- a/developer/MCP-STATUS.md
+++ b/developer/MCP-STATUS.md
@@ -197,7 +197,7 @@ Reference: `developer/PRD-MCP-abstraction-layer.md`
 
 ---
 
-## Workstream C: MCP Client Engine (Future)
+## Workstream C: MCP Client Engine
 
 Reference: `developer/PRD-MCP-client-engine.md`
 
@@ -206,7 +206,7 @@ Reference: `developer/PRD-MCP-client-engine.md`
 | Phase | Scope | GitHub Issue | Status | Updated | Notes |
 |---|---|---|---|---|---|
 | CE-1 | Client Engine Core | https://github.com/Bytes0211/stratifyai/issues/38 | Done | 2026-04-04 | MCPClientEngine core, ServerManager, stdio ClientSession wrapper, config loader, and E2E tool/resource test implemented |
-| CE-2 | Tool Registry & Namespacing | https://github.com/Bytes0211/stratifyai/issues/39 | Planned | 2026-04-03 | Aggregated tool list across servers |
+| CE-2 | Tool Registry & Namespacing | https://github.com/Bytes0211/stratifyai/issues/39 | Done | 2026-04-04 | Namespaced ToolRegistry, per-server lifecycle registration, and verified start/stop/restart behavior |
 | CE-3 | Chat Integration | https://github.com/Bytes0211/stratifyai/issues/40 | Planned | 2026-04-03 | LLM tool_use with MCP tools in conversation |
 | CE-4 | Permissions & Safety | https://github.com/Bytes0211/stratifyai/issues/41 | Planned | 2026-04-03 | Allow/deny/confirm per tool, safety defaults |
 | CE-5 | Web UI Panels | https://github.com/Bytes0211/stratifyai/issues/42 | Planned | 2026-04-03 | Server dashboard, tool discovery, chat badges, permission manager |
@@ -266,11 +266,11 @@ Steps are listed in the same interleaved sequence as the execution order above. 
 
 | Step ID | Step | Status | Updated | Evidence |
 |---|---|---|---|---|
-| CE2-S1 | Implement `ToolRegistry` with register/unregister per server | Planned | 2026-04-04 | - |
-| CE2-S2 | Namespace tools as `{server_id}.{tool_name}` to prevent collisions | Planned | 2026-04-04 | - |
-| CE2-S3 | Handle server connect/disconnect events (auto register/unregister) | Planned | 2026-04-04 | - |
-| CE2-S4 | Implement `list_all()` returning merged tool list across all servers | Planned | 2026-04-04 | - |
-| CE2-S5 | Implement `find_tool(server, name)` lookup | Planned | 2026-04-04 | - |
+| CE2-S1 | Implement `ToolRegistry` with register/unregister per server | Done | 2026-04-04 | stratifyai/mcp_client/tool_registry.py (`register_server_tools`, `unregister_server`, `list_server_tools`) |
+| CE2-S2 | Namespace tools as `{server_id}.{tool_name}` to prevent collisions | Done | 2026-04-04 | stratifyai/mcp_client/tool_registry.py (`namespace=f"{server_id}.{tool_name}"`) |
+| CE2-S3 | Handle server connect/disconnect events (auto register/unregister) | Done | 2026-04-04 | stratifyai/mcp_client/engine.py (`start_server`, `stop_server`, `restart_server`) |
+| CE2-S4 | Implement `list_all()` returning merged tool list across all servers | Done | 2026-04-04 | stratifyai/mcp_client/tool_registry.py (`list_all()`); verified by `uv run pytest tests/test_mcp_client_engine.py` |
+| CE2-S5 | Implement `find_tool(server, name)` lookup | Done | 2026-04-04 | stratifyai/mcp_client/tool_registry.py (`find_tool`, `find_by_namespace`); verified by `uv run pytest tests/test_mcp_client_engine.py` |
 
 #### Step 5: AL-3 — Web UI
 

--- a/stratifyai/mcp_client/engine.py
+++ b/stratifyai/mcp_client/engine.py
@@ -38,17 +38,41 @@ class MCPClientEngine:
         for server in self._servers:
             if not server.enabled or not server.auto_start:
                 continue
-            connection = await self._server_manager.spawn(server)
-            tools_result = await connection.session.list_tools()
-            self._tool_registry.register_server_tools(
-                server.server_id, tools_result.tools
-            )
+            await self.start_server(server.server_id)
+
+    async def start_server(self, server_id: str) -> ServerStatus:
+        """Start one configured server and register its tools."""
+        config = self._server_index.get(server_id)
+        if config is None:
+            raise KeyError(f"Unknown server: {server_id}")
+
+        connection = await self._server_manager.spawn(config)
+        tools_result = await connection.session.list_tools()
+        self._tool_registry.register_server_tools(server_id, tools_result.tools)
+        return self.get_server_status(server_id)
 
     async def stop(self) -> None:
         """Stop all running servers and clear tool registry state."""
         for server_id in list(self._server_index.keys()):
-            await self._server_manager.stop(server_id)
-            self._tool_registry.unregister_server(server_id)
+            await self.stop_server(server_id)
+
+    async def stop_server(self, server_id: str) -> ServerStatus:
+        """Stop one server and unregister its tools."""
+        await self._server_manager.stop(server_id)
+        self._tool_registry.unregister_server(server_id)
+        return self.get_server_status(server_id)
+
+    async def restart_server(self, server_id: str) -> ServerStatus:
+        """Restart one server and refresh its tool registration."""
+        config = self._server_index.get(server_id)
+        if config is None:
+            raise KeyError(f"Unknown server: {server_id}")
+
+        self._tool_registry.unregister_server(server_id)
+        connection = await self._server_manager.restart(config)
+        tools_result = await connection.session.list_tools()
+        self._tool_registry.register_server_tools(server_id, tools_result.tools)
+        return self.get_server_status(server_id)
 
     async def call_tool(self, server: str, tool: str, args: dict) -> dict:
         """Call one tool on a connected server."""
@@ -97,6 +121,10 @@ class MCPClientEngine:
             if status.server_id == server:
                 return status
         raise KeyError(f"Unknown server: {server}")
+
+    def find_tool(self, server_id: str, tool_name: str):
+        """Find one registered tool by server-local name."""
+        return self._tool_registry.find_tool(server_id, tool_name)
 
     async def _require_connection(self, server_id: str):
         connection = self._server_manager.get_connection(server_id)

--- a/stratifyai/mcp_client/tool_registry.py
+++ b/stratifyai/mcp_client/tool_registry.py
@@ -33,17 +33,27 @@ class ToolRegistry:
     def find_tool(self, server_id: str, tool_name: str) -> Tool | None:
         return self._tools_by_server.get(server_id, {}).get(tool_name)
 
+    def find_by_namespace(self, namespace: str) -> Tool | None:
+        server_id, _, tool_name = namespace.partition(".")
+        if not server_id or not tool_name:
+            return None
+        return self.find_tool(server_id, tool_name)
+
+    def list_server_tools(self, server_id: str) -> list[ToolDescriptor]:
+        tools = self._tools_by_server.get(server_id, {})
+        return [
+            ToolDescriptor(
+                server_id=server_id,
+                tool_name=tool_name,
+                namespace=f"{server_id}.{tool_name}",
+                description=tool.description,
+                input_schema=dict(tool.inputSchema),
+            )
+            for tool_name, tool in sorted(tools.items())
+        ]
+
     def list_all(self) -> list[ToolDescriptor]:
         descriptors: list[ToolDescriptor] = []
-        for server_id, tools in sorted(self._tools_by_server.items()):
-            for tool_name, tool in sorted(tools.items()):
-                descriptors.append(
-                    ToolDescriptor(
-                        server_id=server_id,
-                        tool_name=tool_name,
-                        namespace=f"{server_id}.{tool_name}",
-                        description=tool.description,
-                        input_schema=dict(tool.inputSchema),
-                    )
-                )
+        for server_id in sorted(self._tools_by_server):
+            descriptors.extend(self.list_server_tools(server_id))
         return descriptors

--- a/tests/test_mcp_client_engine.py
+++ b/tests/test_mcp_client_engine.py
@@ -68,6 +68,45 @@ def test_tool_registry_namespaces_server_tools() -> None:
     assert registry.list_all() == []
 
 
+def test_tool_registry_handles_multiple_servers_and_namespace_lookup() -> None:
+    registry = ToolRegistry()
+    registry.register_server_tools(
+        "alpha",
+        [
+            Tool(
+                name="echo",
+                description="Echo alpha",
+                inputSchema={"type": "object"},
+            )
+        ],
+    )
+    registry.register_server_tools(
+        "beta",
+        [
+            Tool(
+                name="echo",
+                description="Echo beta",
+                inputSchema={"type": "object"},
+            ),
+            Tool(
+                name="sum",
+                description="Sum values",
+                inputSchema={"type": "object"},
+            ),
+        ],
+    )
+
+    namespaces = [tool.namespace for tool in registry.list_all()]
+    assert namespaces == ["alpha.echo", "beta.echo", "beta.sum"]
+    assert registry.find_tool("beta", "sum") is not None
+    assert registry.find_by_namespace("beta.echo") is not None
+    assert registry.list_server_tools("beta")[1].namespace == "beta.sum"
+
+    registry.unregister_server("alpha")
+    namespaces = [tool.namespace for tool in registry.list_all()]
+    assert namespaces == ["beta.echo", "beta.sum"]
+
+
 @pytest.mark.asyncio
 async def test_mcp_client_engine_start_call_tool_and_get_resource(
     tmp_path: Path,
@@ -122,5 +161,53 @@ async def test_mcp_client_engine_start_call_tool_and_get_resource(
 
         resource = await engine.get_resource("demo", "demo://status")
         assert "ready" in resource
+    finally:
+        await engine.stop()
+
+
+@pytest.mark.asyncio
+async def test_mcp_client_engine_start_stop_and_restart_updates_registry(
+    tmp_path: Path,
+) -> None:
+    server_script = tmp_path / "fake_mcp_server_reconnect.py"
+    server_script.write_text(
+        textwrap.dedent(
+            """
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("demo-reconnect")
+
+            @mcp.tool()
+            async def echo(text: str) -> dict[str, str]:
+                return {"echo": text}
+
+            if __name__ == "__main__":
+                mcp.run(transport="stdio")
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    server = ConfiguredServer(
+        server_id="demo",
+        command=sys.executable,
+        args=[str(server_script)],
+        cwd=tmp_path,
+    )
+    engine = MCPClientEngine(servers=[server])
+
+    try:
+        await engine.start_server("demo")
+        assert [tool.namespace for tool in engine.list_tools()] == ["demo.echo"]
+        assert engine.find_tool("demo", "echo") is not None
+        assert engine.get_server_status("demo").status == "connected"
+
+        await engine.stop_server("demo")
+        assert engine.list_tools() == []
+        assert engine.get_server_status("demo").status == "stopped"
+
+        await engine.restart_server("demo")
+        assert [tool.namespace for tool in engine.list_tools()] == ["demo.echo"]
+        assert engine.get_server_status("demo").status == "connected"
     finally:
         await engine.stop()


### PR DESCRIPTION
feat(MCP): Tool Registry

Closes #39

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `ToolRegistry` with server-namespaced tool lookup (`{server_id}.{tool_name}`) and integrates it into `MCPClientEngine` for per-server register/unregister across the full start/stop/restart lifecycle. The implementation is clean and the test coverage covers the core scenarios well. The only findings are two P2 style suggestions: a missing return-type annotation on `engine.find_tool`, and a missing rollback guard in the three places where `spawn` succeeds but `list_tools()` could fail, leaving the connection and registry out of sync.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all remaining findings are P2 style/hardening suggestions with no impact on current behavior.

The core registry logic is correct, lifecycle integration is well-tested, and no P0/P1 defects were found. The spawn+list_tools inconsistency is a defensive-coding improvement rather than a current breakage.

stratifyai/mcp_client/engine.py — three call sites (start_server, restart_server, _require_connection) share the same pattern that could leave registry and connection state inconsistent on list_tools failure.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| stratifyai/mcp_client/tool_registry.py | New ToolRegistry module with server-namespaced tool lookup, register/unregister lifecycle, and sorted list operations — logic is clean and correct. |
| stratifyai/mcp_client/engine.py | Integrates ToolRegistry into MCPClientEngine; one minor gap where a successful spawn followed by a failing list_tools() leaves the server connected but unregistered in the registry. |
| tests/test_mcp_client_engine.py | Adds well-structured unit and E2E tests covering namespace correctness, multi-server lookup, and start/stop/restart registry lifecycle. |
| developer/MCP-STATUS.md | Status tracker updated to mark CE-2 as Done with evidence links; documentation only, no functional changes. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: stratifyai/mcp_client/engine.py
Line: 49-51

Comment:
**Registry left empty if `list_tools()` fails after successful spawn**

If `connection.session.list_tools()` raises (e.g. the server process crashes immediately after the MCP handshake), `spawn` has already stored the connection in `ServerManager._connections` and returned successfully — but `register_server_tools` is never called. The server is "connected" in the status tracker while the registry reports zero tools for it, and subsequent `call_tool` calls succeed silently against a server whose tools are unknown. Wrapping the `list_tools` + `register` pair in a try/except that calls `stop_server` on failure would keep the two data structures consistent.

```python
        connection = await self._server_manager.spawn(config)
        try:
            tools_result = await connection.session.list_tools()
            self._tool_registry.register_server_tools(server_id, tools_result.tools)
        except Exception:
            await self._server_manager.stop(server_id)
            raise
        return self.get_server_status(server_id)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: stratifyai/mcp_client/engine.py
Line: 125-127

Comment:
**Missing return type annotation**

`find_tool` lacks a return type, inconsistent with every other method in the class. The registry's `find_tool` returns `Tool | None`, so the annotation should match.

```suggestion
    def find_tool(self, server_id: str, tool_name: str) -> Tool | None:
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(MCP): Tool Registry"](https://github.com/bytes0211/stratifyai/commit/ded22b983fa85c695600042f593159461837e25b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27360798)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->