### PR TITLE
PR - Custom MCP Phase 1: API Layer — Custom Server Endpoint

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1711,6 +1711,45 @@ class MCPConfigureRequest(BaseModel):
         return value
 
 
+class MCPCustomServerRequest(BaseModel):
+    """Request model for adding a non-catalog (custom) MCP server."""
+
+    server_id: str
+    command: str
+    args: list[str] = Field(default_factory=list)
+    env: dict[str, str] = Field(default_factory=dict)
+    client: str
+    enabled: bool = True
+    auto_start: bool = True
+    project_root: str | None = None
+    output_path: str | None = None
+    apply: bool = False
+
+    @field_validator("client")
+    @classmethod
+    def validate_client(cls, value: str) -> str:
+        allowed = {"claude-desktop", "claude-code", "cursor", "vscode"}
+        if value not in allowed:
+            raise ValueError(f"client must be one of: {', '.join(sorted(allowed))}")
+        return value
+
+    @field_validator("server_id")
+    @classmethod
+    def validate_server_id(cls, value: str) -> str:
+        if not value or not value.strip():
+            raise ValueError("server_id must be non-empty")
+        if "/" in value or "\\" in value:
+            raise ValueError("server_id must not contain path separators")
+        return value.strip()
+
+    @field_validator("command")
+    @classmethod
+    def validate_command(cls, value: str) -> str:
+        if not value or not value.strip():
+            raise ValueError("command must be non-empty")
+        return value.strip()
+
+
 class MCPResetRequest(BaseModel):
     """Request model for MCP config reset/remove actions."""
 
@@ -2896,6 +2935,100 @@ async def configure_mcp(
         }
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=sanitize_error(str(exc))) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=sanitize_error(str(exc))) from exc
+
+
+@app.post("/api/mcp/add-custom")
+async def add_custom_mcp_server(
+    payload: MCPCustomServerRequest,
+    _: None = Depends(verify_api_key),
+):
+    """Add a non-catalog (custom) MCP server to a client config file."""
+    try:
+        warnings: list[str] = []
+        server_config = {"command": payload.command}
+        if payload.args:
+            server_config["args"] = payload.args
+        if payload.env:
+            server_config["env"] = payload.env
+
+        if payload.client == "claude-code":
+            cmd_parts = [
+                "claude",
+                "mcp",
+                "add",
+                payload.server_id,
+                "--",
+                payload.command,
+            ]
+            cmd_parts.extend(payload.args)
+            commands = [" ".join(cmd_parts)]
+            applied = False
+            if payload.apply:
+                if not payload.output_path:
+                    warnings.append(
+                        "claude-code: apply requested but no output_path provided. "
+                        "Use 'claude mcp add' commands directly instead."
+                    )
+                else:
+                    output_path = Path(payload.output_path)
+                    output_path.parent.mkdir(parents=True, exist_ok=True)
+                    output_path.write_text("\n".join(commands) + "\n", encoding="utf-8")
+                    applied = True
+            return {
+                "applied": applied,
+                "config": None,
+                "commands": commands,
+                "path": payload.output_path,
+                "warnings": warnings,
+            }
+
+        # Build the config dict in the format write_client_config expects.
+        if payload.client == "vscode":
+            config = {"mcp": {"servers": {payload.server_id: server_config}}}
+        else:
+            config = {"mcpServers": {payload.server_id: server_config}}
+
+        path = detect_client_config_path(payload.client, payload.project_root)
+        applied = False
+
+        if payload.apply:
+            written = write_client_config(
+                client=payload.client,
+                config=config,
+                project_root=payload.project_root,
+                output_path=payload.output_path,
+            )
+            path = written
+            applied = True
+
+            # Write enabled/auto_start metadata.
+            write_mcp_client_settings(
+                client=payload.client,
+                settings={
+                    "servers": {
+                        payload.server_id: {
+                            "enabled": payload.enabled,
+                            "auto_start": payload.auto_start,
+                        }
+                    }
+                },
+                project_root=payload.project_root,
+                output_path=payload.output_path,
+            )
+
+            global _mcp_chat_engine
+            if _mcp_chat_engine is not None:
+                await get_mcp_chat_engine(refresh=True)
+
+        return {
+            "applied": applied,
+            "config": config,
+            "commands": [],
+            "path": str(path) if path is not None else payload.output_path,
+            "warnings": warnings,
+        }
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=sanitize_error(str(exc))) from exc
 

--- a/api/main.py
+++ b/api/main.py
@@ -5,6 +5,7 @@ import hashlib
 import hmac
 import logging
 import os
+import shlex
 import threading
 import time
 from collections import defaultdict, deque
@@ -2147,7 +2148,7 @@ async def _execute_mcp_tool_test(tool_name: str, payload: dict[str, Any]) -> Any
                     status_code=400, detail=f"Invalid message role: {raw_role!r}"
                 )
             request_messages.append(
-                Message(role=raw_role, content=str(item.get("content", "")))  # type: ignore[arg-type]
+                Message(role=raw_role, content=str(item.get("content", "")))
             )
         client = get_tracked_client(provider)
         response = await client.chat_completion(
@@ -2183,7 +2184,7 @@ async def _execute_mcp_tool_test(tool_name: str, payload: dict[str, Any]) -> Any
                     status_code=400, detail=f"Invalid message role: {raw_role!r}"
                 )
             request_messages.append(
-                Message(role=raw_role, content=str(item.get("content", "")))  # type: ignore[arg-type]
+                Message(role=raw_role, content=str(item.get("content", "")))
             )
         provider, model = router.route(
             request_messages,
@@ -2947,23 +2948,19 @@ async def add_custom_mcp_server(
     """Add a non-catalog (custom) MCP server to a client config file."""
     try:
         warnings: list[str] = []
-        server_config = {"command": payload.command}
+        server_config: dict[str, Any] = {"command": payload.command}
         if payload.args:
             server_config["args"] = payload.args
         if payload.env:
             server_config["env"] = payload.env
 
         if payload.client == "claude-code":
-            cmd_parts = [
-                "claude",
-                "mcp",
-                "add",
-                payload.server_id,
-                "--",
-                payload.command,
-            ]
-            cmd_parts.extend(payload.args)
-            commands = [" ".join(cmd_parts)]
+            cmd_parts = ["claude", "mcp", "add", payload.server_id, payload.command]
+            for arg in payload.args:
+                cmd_parts.append(arg)
+            for key, value in payload.env.items():
+                cmd_parts.extend(["-e", f"{key}={value}"])
+            commands = [" ".join(shlex.quote(p) for p in cmd_parts)]
             applied = False
             if payload.apply:
                 if not payload.output_path:
@@ -2985,6 +2982,7 @@ async def add_custom_mcp_server(
             }
 
         # Build the config dict in the format write_client_config expects.
+        config: dict[str, Any]
         if payload.client == "vscode":
             config = {"mcp": {"servers": {payload.server_id: server_config}}}
         else:

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -14,6 +14,7 @@ import type {
   McpStatusResponse,
   McpConfigureRequest,
   McpConfigureResponse,
+  McpCustomServerRequest,
   McpResetRequest,
   McpResetResponse,
   McpToolsResponse,
@@ -124,6 +125,13 @@ export async function getMcpStatus(
 
 export async function configureMcp(req: McpConfigureRequest): Promise<McpConfigureResponse> {
   return request<McpConfigureResponse>('/mcp/configure', {
+    method: 'POST',
+    body: JSON.stringify(req),
+  });
+}
+
+export async function configureCustomMcp(req: McpCustomServerRequest): Promise<McpConfigureResponse> {
+  return request<McpConfigureResponse>('/mcp/add-custom', {
     method: 'POST',
     body: JSON.stringify(req),
   });

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -272,6 +272,19 @@ export interface McpConfigureResponse {
   warnings: string[];
 }
 
+export interface McpCustomServerRequest {
+  server_id: string;
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  client: 'claude-desktop' | 'claude-code' | 'cursor' | 'vscode';
+  enabled?: boolean;
+  auto_start?: boolean;
+  project_root?: string;
+  output_path?: string;
+  apply?: boolean;
+}
+
 export interface McpResetRequest {
   client: 'claude-desktop' | 'claude-code' | 'cursor' | 'vscode';
   server_ids?: string[];

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -712,6 +712,7 @@ def test_add_custom_mcp_server_claude_code_returns_commands():
             "server_id": "my-server",
             "command": "python",
             "args": ["-m", "my_module"],
+            "env": {"MY_KEY": "secret"},
             "client": "claude-code",
             "apply": False,
         },
@@ -721,6 +722,36 @@ def test_add_custom_mcp_server_claude_code_returns_commands():
     body = resp.json()
     assert body["config"] is None
     assert len(body["commands"]) == 1
-    assert "claude mcp add my-server" in body["commands"][0]
-    assert "python" in body["commands"][0]
-    assert "-m" in body["commands"][0]
+    cmd = body["commands"][0]
+    # No '--' separator, matches build_claude_code_commands pattern.
+    assert "-- " not in cmd
+    assert "claude mcp add my-server python" in cmd
+    assert "-m" in cmd
+    # Env vars emitted as -e KEY=VAL pairs.
+    assert "-e MY_KEY=secret" in cmd
+
+
+@patch.dict("os.environ", {"STRATIFYAI_API_KEY": "api-secret"})
+def test_add_custom_mcp_server_claude_code_quotes_spaces():
+    """Arguments with spaces are shell-quoted in claude-code commands."""
+    from api.main import app
+
+    client = TestClient(app)
+    headers = {"Authorization": "Bearer api-secret"}
+
+    resp = client.post(
+        "/api/mcp/add-custom",
+        json={
+            "server_id": "my-server",
+            "command": "/path/to/my program",
+            "args": ["--dir", "/tmp/my folder"],
+            "client": "claude-code",
+            "apply": False,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    cmd = resp.json()["commands"][0]
+    # shlex.quote wraps tokens containing spaces in single quotes.
+    assert "'/path/to/my program'" in cmd
+    assert "'/tmp/my folder'" in cmd

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -578,3 +578,149 @@ def test_websocket_stream_returns_structured_validation_and_token_errors():
 
     assert token_limit["error"] == "input_too_long"
     assert token_limit["detail"] == "Too many tokens"
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — POST /api/mcp/add-custom
+# ---------------------------------------------------------------------------
+
+
+@patch.dict("os.environ", {"STRATIFYAI_API_KEY": "api-secret"})
+def test_add_custom_mcp_server_preview_returns_config(tmp_path):
+    """Valid custom server request with apply=False returns correct config."""
+    from api.main import app
+
+    client = TestClient(app)
+    headers = {"Authorization": "Bearer api-secret"}
+
+    resp = client.post(
+        "/api/mcp/add-custom",
+        json={
+            "server_id": "my-server",
+            "command": "python",
+            "args": ["-m", "my_module"],
+            "env": {"MY_KEY": "secret"},
+            "client": "cursor",
+            "apply": False,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["applied"] is False
+    assert body["commands"] == []
+    config = body["config"]
+    assert "mcpServers" in config
+    server = config["mcpServers"]["my-server"]
+    assert server["command"] == "python"
+    assert server["args"] == ["-m", "my_module"]
+    assert server["env"] == {"MY_KEY": "secret"}
+
+
+@patch.dict("os.environ", {"STRATIFYAI_API_KEY": "api-secret"})
+def test_add_custom_mcp_server_apply_writes_config(tmp_path):
+    """apply=True calls write_client_config with expected args."""
+    import api.main as api_main
+    from api.main import app
+
+    config_path = tmp_path / ".cursor" / "mcp.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps({"mcpServers": {}}), encoding="utf-8")
+
+    original_engine = api_main._mcp_chat_engine
+    api_main._mcp_chat_engine = None
+    try:
+        client = TestClient(app)
+        headers = {"Authorization": "Bearer api-secret"}
+
+        resp = client.post(
+            "/api/mcp/add-custom",
+            json={
+                "server_id": "my-server",
+                "command": "node",
+                "args": ["server.js"],
+                "env": {},
+                "client": "cursor",
+                "output_path": str(config_path),
+                "apply": True,
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["applied"] is True
+
+        # Verify the config was written to disk.
+        written = json.loads(config_path.read_text(encoding="utf-8"))
+        assert "my-server" in written["mcpServers"]
+        assert written["mcpServers"]["my-server"]["command"] == "node"
+    finally:
+        api_main._mcp_chat_engine = original_engine
+
+
+@patch.dict("os.environ", {"STRATIFYAI_API_KEY": "api-secret"})
+def test_add_custom_mcp_server_missing_command_returns_422():
+    """Missing or empty command returns 422 (validation error)."""
+    from api.main import app
+
+    client = TestClient(app)
+    headers = {"Authorization": "Bearer api-secret"}
+
+    resp = client.post(
+        "/api/mcp/add-custom",
+        json={
+            "server_id": "my-server",
+            "command": "",
+            "client": "cursor",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+@patch.dict("os.environ", {"STRATIFYAI_API_KEY": "api-secret"})
+def test_add_custom_mcp_server_invalid_client_returns_422():
+    """Invalid client value returns 422 (validation error)."""
+    from api.main import app
+
+    client = TestClient(app)
+    headers = {"Authorization": "Bearer api-secret"}
+
+    resp = client.post(
+        "/api/mcp/add-custom",
+        json={
+            "server_id": "my-server",
+            "command": "python",
+            "client": "invalid-client",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+@patch.dict("os.environ", {"STRATIFYAI_API_KEY": "api-secret"})
+def test_add_custom_mcp_server_claude_code_returns_commands():
+    """claude-code client returns shell commands instead of config."""
+    from api.main import app
+
+    client = TestClient(app)
+    headers = {"Authorization": "Bearer api-secret"}
+
+    resp = client.post(
+        "/api/mcp/add-custom",
+        json={
+            "server_id": "my-server",
+            "command": "python",
+            "args": ["-m", "my_module"],
+            "client": "claude-code",
+            "apply": False,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["config"] is None
+    assert len(body["commands"]) == 1
+    assert "claude mcp add my-server" in body["commands"][0]
+    assert "python" in body["commands"][0]
+    assert "-m" in body["commands"][0]


### PR DESCRIPTION
feat(MCP)UI create api layer

Closes #64

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the API layer for custom (non-catalog) MCP server configuration, adding the `MCPCustomServerRequest` model, the `/api/mcp/add-custom` endpoint, matching TypeScript types, a client wrapper, and six new tests. The previously flagged issues from round one (missing `env` pairs in claude-code commands, the spurious `--` separator, and unquoted shell arguments) are all resolved in this version.

<h3>Confidence Score: 4/5</h3>

Safe to merge with minor follow-up work; no new P0/P1 regressions introduced.

All three functional P1 issues from the previous review round are now fixed. The two remaining findings are P2: the server_id interior-whitespace gap is unlikely to be hit in practice and carries no security risk given shlex.quote, and the test coverage gap is a testing quality concern rather than a correctness defect. One prior thread item (missing response_model) is still open but does not affect runtime correctness.

Minor attention on api/main.py (server_id validator) and tests/test_api_endpoints.py (merge-preservation assertion).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/main.py | Adds `MCPCustomServerRequest` model and `/api/mcp/add-custom` endpoint; previous-round fixes for env vars, `--` separator, and `shlex.quote` are all applied; `server_id` validator still allows interior whitespace; `response_model` is absent (noted in prior thread). |
| frontend/src/lib/api/client.ts | Adds `configureCustomMcp` wrapper that POSTs to `/mcp/add-custom` and reuses `McpConfigureResponse`; the response shape matches the backend's return value for all client types. |
| frontend/src/lib/api/types.ts | Adds `McpCustomServerRequest` interface that correctly mirrors the backend Pydantic model, including optional fields and the constrained `client` union type. |
| tests/test_api_endpoints.py | Six new tests covering preview, apply, validation errors, claude-code command generation, and shell-quoting; the `apply=True` test doesn't verify that pre-existing servers are preserved after write, which would catch a destructive-overwrite regression. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: api/main.py
Line: 1738-1744

Comment:
**`server_id` permits interior whitespace**

`value.strip()` removes leading/trailing whitespace but a value like `"my server"` passes validation. For non-claude-code clients this becomes a JSON key `"my server"`, which is unusual and may confuse downstream tools. For claude-code the `shlex.quote` call handles it safely at the shell level, but the claude CLI itself may not accept a server-id that contains a space. Consider rejecting any `server_id` whose stripped form still contains whitespace:

```suggestion
    @field_validator("server_id")
    @classmethod
    def validate_server_id(cls, value: str) -> str:
        if not value or not value.strip():
            raise ValueError("server_id must be non-empty")
        if "/" in value or "\\" in value:
            raise ValueError("server_id must not contain path separators")
        stripped = value.strip()
        if " " in stripped or "\t" in stripped:
            raise ValueError("server_id must not contain whitespace")
        return stripped
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: tests/test_api_endpoints.py
Line: 621-660

Comment:
**`apply=True` test doesn't verify pre-existing servers are preserved**

`test_add_custom_mcp_server_apply_writes_config` starts with `{"mcpServers": {}}` (empty), so it cannot detect a destructive overwrite. If `write_client_config` replaces the whole file instead of merging, existing servers would be silently deleted. Consider pre-seeding the config with a second server and asserting it still appears after the write:

```python
config_path.write_text(
    json.dumps({"mcpServers": {"existing-server": {"command": "old"}}}),
    encoding="utf-8",
)
# ... call the endpoint ...
written = json.loads(config_path.read_text(encoding="utf-8"))
assert "existing-server" in written["mcpServers"]  # must survive the write
assert "my-server" in written["mcpServers"]
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fixes(MCP)fixes on PR 69 api layer"](https://github.com/bytes0211/stratifyai/commit/1940c06bf7f97bbb14b57f0f1c4e495a69c2c09d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28018630)</sub>

<!-- /greptile_comment -->