### PR TITLE
PR - Custom MCP Phase 2: Frontend — Add Custom Server Form

### DIFF
--- a/frontend/src/lib/components/mcp/MCPServersPage.svelte
+++ b/frontend/src/lib/components/mcp/MCPServersPage.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import {
     configureMcp,
+    configureCustomMcp,
     getMcpCatalog,
     getMcpClientPermissions,
     getMcpClients,
@@ -29,7 +30,9 @@
     CheckCircle2,
     Copy,
     Download,
+    Minus,
     Play,
+    Plus,
     PlugZap,
     Power,
     RefreshCw,
@@ -41,6 +44,8 @@
     Wrench,
   } from 'lucide-svelte';
 
+  type ViewMode = 'catalog' | 'custom';
+
   let catalog: McpCatalogResponse | null = null;
   let clients: McpClientInfo[] = [];
   let selectedClient: McpConfigureRequest['client'] = 'cursor';
@@ -50,6 +55,15 @@
   let selectedServerIds: string[] = [];
   let envValues: Record<string, string> = {};
   let argValues: Record<string, string> = {};
+  let viewMode: ViewMode = 'catalog';
+
+  // Custom server form state
+  let customServerId = '';
+  let customCommand = '';
+  let customArgs: string[] = [''];
+  let customEnvKeys: string[] = [''];
+  let customEnvValues: string[] = [''];
+  let customFormErrors: Record<string, string> = {};
   let statusData: McpStatusResponse | null = null;
   let runtimeServers: McpClientServerInfo[] = [];
   let runtimeTools: McpClientToolInfo[] = [];
@@ -429,6 +443,119 @@
     return Boolean(statusData?.configured?.[serverId]);
   }
 
+  function isCatalogServer(serverId: string): boolean {
+    return catalog?.servers.some((server) => server.id === serverId) ?? false;
+  }
+
+  // --- Custom server form helpers ---
+
+  function validateCustomForm(): boolean {
+    const errors: Record<string, string> = {};
+    if (!customServerId.trim()) {
+      errors.serverId = 'Server ID is required.';
+    } else if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(customServerId.trim())) {
+      errors.serverId = 'Must be lowercase alphanumeric with hyphens (e.g. my-server).';
+    }
+    if (!customCommand.trim()) {
+      errors.command = 'Command is required.';
+    }
+    customFormErrors = errors;
+    return Object.keys(errors).length === 0;
+  }
+
+  function addArgRow() {
+    customArgs = [...customArgs, ''];
+  }
+
+  function removeArgRow(index: number) {
+    customArgs = customArgs.filter((_, i) => i !== index);
+    if (customArgs.length === 0) customArgs = [''];
+  }
+
+  function updateArgRow(index: number, value: string) {
+    customArgs = customArgs.map((v, i) => (i === index ? value : v));
+  }
+
+  function addEnvRow() {
+    customEnvKeys = [...customEnvKeys, ''];
+    customEnvValues = [...customEnvValues, ''];
+  }
+
+  function removeEnvRow(index: number) {
+    customEnvKeys = customEnvKeys.filter((_, i) => i !== index);
+    customEnvValues = customEnvValues.filter((_, i) => i !== index);
+    if (customEnvKeys.length === 0) {
+      customEnvKeys = [''];
+      customEnvValues = [''];
+    }
+  }
+
+  function updateEnvKey(index: number, value: string) {
+    customEnvKeys = customEnvKeys.map((v, i) => (i === index ? value : v));
+  }
+
+  function updateEnvVal(index: number, value: string) {
+    customEnvValues = customEnvValues.map((v, i) => (i === index ? value : v));
+  }
+
+  function resetCustomForm() {
+    customServerId = '';
+    customCommand = '';
+    customArgs = [''];
+    customEnvKeys = [''];
+    customEnvValues = [''];
+    customFormErrors = {};
+  }
+
+  function buildCustomEnvMap(): Record<string, string> {
+    const env: Record<string, string> = {};
+    for (let i = 0; i < customEnvKeys.length; i++) {
+      const key = customEnvKeys[i].trim();
+      const value = customEnvValues[i]?.trim() ?? '';
+      if (key) env[key] = value;
+    }
+    return env;
+  }
+
+  function buildCustomArgsArray(): string[] {
+    return customArgs.map((a) => a.trim()).filter(Boolean);
+  }
+
+  async function generateCustomConfig(apply = false) {
+    if (!validateCustomForm()) return;
+
+    try {
+      actionLoading = true;
+      error = null;
+      copyMessage = '';
+      preview = await configureCustomMcp({
+        server_id: customServerId.trim(),
+        command: customCommand.trim(),
+        args: buildCustomArgsArray(),
+        env: buildCustomEnvMap(),
+        client: selectedClient,
+        enabled: true,
+        auto_start: true,
+        project_root: projectRoot || undefined,
+        apply,
+      });
+      statusMessage = preview.applied
+        ? `Custom server "${customServerId}" applied${preview.path ? ` to ${preview.path}` : ''}.`
+        : selectedClient === 'claude-code'
+          ? 'Commands generated for Claude Code.'
+          : 'Custom server preview updated.';
+
+      if (apply) {
+        resetCustomForm();
+        await refreshStatus();
+      }
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Failed to configure custom MCP server';
+    } finally {
+      actionLoading = false;
+    }
+  }
+
   $: categories = catalog
     ? ['all', ...Array.from(new Set(catalog.servers.map((server) => server.category))).sort()]
     : ['all'];
@@ -542,6 +669,11 @@
           <div class="configured-list">
             {#each Object.keys(statusData.configured) as serverId}
               <span class="chip configured">{serverId}</span>
+              {#if isCatalogServer(serverId)}
+                <span class="chip catalog-badge">catalog</span>
+              {:else}
+                <span class="chip custom-badge">custom</span>
+              {/if}
             {/each}
           </div>
         {:else}
@@ -553,17 +685,28 @@
     <section class="card filter-panel">
       <div class="section-title">
         <PlugZap size={18} />
-        <h2>Catalog Browser</h2>
+        <h2>{viewMode === 'catalog' ? 'Catalog Browser' : 'Add Custom Server'}</h2>
       </div>
 
-      <div class="filter-row">
-        <input type="text" bind:value={searchQuery} placeholder="Search by name, id, or tag" />
-        <select bind:value={selectedCategory}>
-          {#each categories as category}
-            <option value={category}>{category === 'all' ? 'All categories' : category}</option>
-          {/each}
-        </select>
+      <div class="tab-row">
+        <button class:active={viewMode === 'catalog'} class="tab-button" on:click={() => viewMode = 'catalog'}>
+          Catalog
+        </button>
+        <button class:active={viewMode === 'custom'} class="tab-button" on:click={() => viewMode = 'custom'}>
+          Custom
+        </button>
       </div>
+
+      {#if viewMode === 'catalog'}
+        <div class="filter-row">
+          <input type="text" bind:value={searchQuery} placeholder="Search by name, id, or tag" />
+          <select bind:value={selectedCategory}>
+            {#each categories as category}
+              <option value={category}>{category === 'all' ? 'All categories' : category}</option>
+            {/each}
+          </select>
+        </div>
+      {/if}
     </section>
 
     {#if displayError}
@@ -574,61 +717,146 @@
     {/if}
 
     <div class="content-grid">
-      <section class="catalog-grid">
-        {#each filteredServers as server (server.id)}
-          <article class:selected={selectedServerIds.includes(server.id)} class:configured={isConfigured(server.id)} class="server-card card">
-            <div class="server-card__header">
-              <div>
-                <h3>{server.name}</h3>
-                <p>{server.description}</p>
+      {#if viewMode === 'catalog'}
+        <section class="catalog-grid">
+          {#each filteredServers as server (server.id)}
+            <article class:selected={selectedServerIds.includes(server.id)} class:configured={isConfigured(server.id)} class="server-card card">
+              <div class="server-card__header">
+                <div>
+                  <h3>{server.name}</h3>
+                  <p>{server.description}</p>
+                </div>
+                <button class:selected={selectedServerIds.includes(server.id)} class="toggle-button" on:click={() => toggleServer(server.id)}>
+                  {selectedServerIds.includes(server.id) ? 'Selected' : 'Select'}
+                </button>
               </div>
-              <button class:selected={selectedServerIds.includes(server.id)} class="toggle-button" on:click={() => toggleServer(server.id)}>
-                {selectedServerIds.includes(server.id) ? 'Selected' : 'Select'}
-              </button>
-            </div>
 
-            <div class="server-meta">
-              <span class="chip">{server.category}</span>
-              <span class="chip">{server.install_method}</span>
-              {#if isConfigured(server.id)}
-                <span class="chip configured">Configured</span>
+              <div class="server-meta">
+                <span class="chip">{server.category}</span>
+                <span class="chip">{server.install_method}</span>
+                {#if isConfigured(server.id)}
+                  <span class="chip configured">Configured</span>
+                {/if}
+              </div>
+
+              {#if server.website}
+                <a class="website-link" href={server.website} target="_blank" rel="noreferrer">Docs ↗</a>
               {/if}
+
+              {#if selectedServerIds.includes(server.id) && (server.env_vars.length > 0 || server.user_args.length > 0)}
+                <div class="server-form">
+                  {#each server.env_vars as envVar}
+                    <label>
+                      <span>{envVar.name}{envVar.required ? ' *' : ''}</span>
+                      <input
+                        type={envVar.secret ? 'password' : 'text'}
+                        value={envValues[envVar.name] ?? ''}
+                        placeholder={envVar.description || envVar.name}
+                        on:input={(event) => updateEnvValue(envVar.name, (event.currentTarget as HTMLInputElement).value)}
+                      />
+                    </label>
+                  {/each}
+
+                  {#each server.user_args as userArg}
+                    <label>
+                      <span>{userArg.name}{userArg.required ? ' *' : ''}</span>
+                      <input
+                        type="text"
+                        value={argValues[`${server.id}.${userArg.name}`] ?? userArg.example ?? ''}
+                        placeholder={userArg.description || userArg.name}
+                        on:input={(event) => updateArgValue(server.id, userArg.name, (event.currentTarget as HTMLInputElement).value)}
+                      />
+                    </label>
+                  {/each}
+                </div>
+              {/if}
+            </article>
+          {/each}
+        </section>
+      {:else}
+        <section class="custom-form-section card">
+          <p class="muted">Define a non-catalog MCP server by providing its command, arguments, and environment variables.</p>
+
+          <div class="custom-form">
+            <label>
+              <span>Server ID *</span>
+              <input
+                type="text"
+                bind:value={customServerId}
+                placeholder="my-custom-server"
+                class:input-error={customFormErrors.serverId}
+              />
+              {#if customFormErrors.serverId}
+                <span class="field-error">{customFormErrors.serverId}</span>
+              {/if}
+            </label>
+
+            <label>
+              <span>Command *</span>
+              <input
+                type="text"
+                bind:value={customCommand}
+                placeholder="npx, uvx, node, python ..."
+                class:input-error={customFormErrors.command}
+              />
+              {#if customFormErrors.command}
+                <span class="field-error">{customFormErrors.command}</span>
+              {/if}
+            </label>
+
+            <div class="repeatable-section">
+              <div class="repeatable-header">
+                <span>Arguments</span>
+                <button class="icon-button" on:click={addArgRow} title="Add argument">
+                  <Plus size={14} />
+                </button>
+              </div>
+              {#each customArgs as arg, i}
+                <div class="repeatable-row">
+                  <input
+                    type="text"
+                    value={arg}
+                    placeholder="e.g. -y, @modelcontextprotocol/server-github"
+                    on:input={(event) => updateArgRow(i, (event.currentTarget as HTMLInputElement).value)}
+                  />
+                  <button class="icon-button danger" on:click={() => removeArgRow(i)} title="Remove argument">
+                    <Minus size={14} />
+                  </button>
+                </div>
+              {/each}
             </div>
 
-            {#if server.website}
-              <a class="website-link" href={server.website} target="_blank" rel="noreferrer">Docs ↗</a>
-            {/if}
-
-            {#if selectedServerIds.includes(server.id) && (server.env_vars.length > 0 || server.user_args.length > 0)}
-              <div class="server-form">
-                {#each server.env_vars as envVar}
-                  <label>
-                    <span>{envVar.name}{envVar.required ? ' *' : ''}</span>
-                    <input
-                      type={envVar.secret ? 'password' : 'text'}
-                      value={envValues[envVar.name] ?? ''}
-                      placeholder={envVar.description || envVar.name}
-                      on:input={(event) => updateEnvValue(envVar.name, (event.currentTarget as HTMLInputElement).value)}
-                    />
-                  </label>
-                {/each}
-
-                {#each server.user_args as userArg}
-                  <label>
-                    <span>{userArg.name}{userArg.required ? ' *' : ''}</span>
-                    <input
-                      type="text"
-                      value={argValues[`${server.id}.${userArg.name}`] ?? userArg.example ?? ''}
-                      placeholder={userArg.description || userArg.name}
-                      on:input={(event) => updateArgValue(server.id, userArg.name, (event.currentTarget as HTMLInputElement).value)}
-                    />
-                  </label>
-                {/each}
+            <div class="repeatable-section">
+              <div class="repeatable-header">
+                <span>Environment Variables</span>
+                <button class="icon-button" on:click={addEnvRow} title="Add env var">
+                  <Plus size={14} />
+                </button>
               </div>
-            {/if}
-          </article>
-        {/each}
-      </section>
+              {#each customEnvKeys as key, i}
+                <div class="repeatable-row env-row">
+                  <input
+                    type="text"
+                    value={key}
+                    placeholder="KEY"
+                    on:input={(event) => updateEnvKey(i, (event.currentTarget as HTMLInputElement).value)}
+                  />
+                  <span class="env-separator">=</span>
+                  <input
+                    type="text"
+                    value={customEnvValues[i] ?? ''}
+                    placeholder="value"
+                    on:input={(event) => updateEnvVal(i, (event.currentTarget as HTMLInputElement).value)}
+                  />
+                  <button class="icon-button danger" on:click={() => removeEnvRow(i)} title="Remove env var">
+                    <Minus size={14} />
+                  </button>
+                </div>
+              {/each}
+            </div>
+          </div>
+        </section>
+      {/if}
 
       <aside class="preview-panel card">
         <div class="section-title">
@@ -636,18 +864,33 @@
           <h2>Preview & Apply</h2>
         </div>
 
-        <div class="action-row">
-          <Button variant="primary" on:click={() => generateConfig(false)} loading={actionLoading}>
-            Preview config
-          </Button>
-          <Button
-            variant="secondary"
-            on:click={() => generateConfig(true)}
-            disabled={actionLoading || !selectedClientInfo?.supports_apply}
-          >
-            {selectedClientInfo?.supports_apply ? 'Apply config' : 'Commands only'}
-          </Button>
-        </div>
+        {#if viewMode === 'catalog'}
+          <div class="action-row">
+            <Button variant="primary" on:click={() => generateConfig(false)} loading={actionLoading}>
+              Preview config
+            </Button>
+            <Button
+              variant="secondary"
+              on:click={() => generateConfig(true)}
+              disabled={actionLoading || !selectedClientInfo?.supports_apply}
+            >
+              {selectedClientInfo?.supports_apply ? 'Apply config' : 'Commands only'}
+            </Button>
+          </div>
+        {:else}
+          <div class="action-row">
+            <Button variant="primary" on:click={() => generateCustomConfig(false)} loading={actionLoading}>
+              Preview config
+            </Button>
+            <Button
+              variant="secondary"
+              on:click={() => generateCustomConfig(true)}
+              disabled={actionLoading || !selectedClientInfo?.supports_apply}
+            >
+              {selectedClientInfo?.supports_apply ? 'Apply config' : 'Commands only'}
+            </Button>
+          </div>
+        {/if}
 
         <div class="action-row secondary-actions">
           <Button
@@ -683,7 +926,7 @@
           </div>
         {/if}
 
-        <pre class="preview-output">{renderedPreview || 'Select one or more servers, then click “Preview config”.'}</pre>
+        <pre class="preview-output">{renderedPreview || (viewMode === 'catalog' ? 'Select one or more servers, then click "Preview config".' : 'Fill in the custom server form, then click "Preview config".')}</pre>
       </aside>
     </div>
 
@@ -1150,6 +1393,131 @@
   .filter-row,
   .action-row {
     flex-wrap: wrap;
+  }
+
+  .tab-row {
+    display: flex;
+    gap: $space-2;
+    margin-bottom: $space-3;
+  }
+
+  .tab-button {
+    padding: $space-2 $space-4;
+    border-radius: $radius-lg;
+    border: 1px solid var(--bg-hover);
+    background: var(--bg-base);
+    color: var(--text-secondary);
+    font-size: $text-sm;
+    font-weight: $font-medium;
+    cursor: pointer;
+    transition: all $transition-fast;
+
+    &:hover {
+      background: var(--bg-elevated);
+      color: var(--text-primary);
+    }
+
+    &.active {
+      background: var(--accent);
+      color: #0f172a;
+      border-color: transparent;
+    }
+  }
+
+  .custom-form-section {
+    display: flex;
+    flex-direction: column;
+    gap: $space-3;
+  }
+
+  .custom-form {
+    display: flex;
+    flex-direction: column;
+    gap: $space-4;
+  }
+
+  .repeatable-section {
+    display: flex;
+    flex-direction: column;
+    gap: $space-2;
+  }
+
+  .repeatable-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    color: var(--text-secondary);
+    font-size: $text-sm;
+  }
+
+  .repeatable-row {
+    display: flex;
+    align-items: center;
+    gap: $space-2;
+
+    input {
+      flex: 1;
+    }
+  }
+
+  .env-row {
+    input:first-of-type {
+      flex: 0.4;
+    }
+
+    input:last-of-type {
+      flex: 0.6;
+    }
+  }
+
+  .env-separator {
+    color: var(--text-secondary);
+    font-weight: $font-medium;
+    flex-shrink: 0;
+  }
+
+  .icon-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    flex-shrink: 0;
+    border-radius: $radius-lg;
+    border: 1px solid var(--bg-hover);
+    background: var(--bg-elevated);
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: all $transition-fast;
+
+    &:hover {
+      background: var(--bg-hover);
+      color: var(--text-primary);
+    }
+
+    &.danger:hover {
+      color: #ef4444;
+      border-color: rgba(239, 68, 68, 0.4);
+    }
+  }
+
+  .input-error {
+    border-color: #ef4444 !important;
+  }
+
+  .field-error {
+    color: #ef4444;
+    font-size: $text-xs;
+  }
+
+  .catalog-badge {
+    background: rgba(99, 102, 241, 0.14);
+    color: #818cf8;
+  }
+
+  .custom-badge {
+    background: rgba(245, 158, 11, 0.14);
+    color: #f59e0b;
   }
 
   .secondary-actions {

--- a/frontend/src/lib/components/mcp/MCPServersPage.svelte
+++ b/frontend/src/lib/components/mcp/MCPServersPage.svelte
@@ -689,10 +689,10 @@
       </div>
 
       <div class="tab-row">
-        <button class:active={viewMode === 'catalog'} class="tab-button" on:click={() => viewMode = 'catalog'}>
+        <button class:active={viewMode === 'catalog'} class="tab-button" on:click={() => { viewMode = 'catalog'; preview = null; statusMessage = ''; }}>
           Catalog
         </button>
-        <button class:active={viewMode === 'custom'} class="tab-button" on:click={() => viewMode = 'custom'}>
+        <button class:active={viewMode === 'custom'} class="tab-button" on:click={() => { viewMode = 'custom'; preview = null; statusMessage = ''; }}>
           Custom
         </button>
       </div>
@@ -806,7 +806,7 @@
 
             <div class="repeatable-section">
               <div class="repeatable-header">
-                <span>Arguments</span>
+                <span>Arguments (one per row)</span>
                 <button class="icon-button" on:click={addArgRow} title="Add argument">
                   <Plus size={14} />
                 </button>
@@ -816,7 +816,7 @@
                   <input
                     type="text"
                     value={arg}
-                    placeholder="e.g. -y, @modelcontextprotocol/server-github"
+                    placeholder="e.g. -y"
                     on:input={(event) => updateArgRow(i, (event.currentTarget as HTMLInputElement).value)}
                   />
                   <button class="icon-button danger" on:click={() => removeArgRow(i)} title="Remove argument">
@@ -843,7 +843,7 @@
                   />
                   <span class="env-separator">=</span>
                   <input
-                    type="text"
+                    type="password"
                     value={customEnvValues[i] ?? ''}
                     placeholder="value"
                     on:input={(event) => updateEnvVal(i, (event.currentTarget as HTMLInputElement).value)}

--- a/frontend/src/lib/components/mcp/MCPServersPage.test.ts
+++ b/frontend/src/lib/components/mcp/MCPServersPage.test.ts
@@ -1,0 +1,534 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — values referenced inside vi.mock() factories
+// ---------------------------------------------------------------------------
+const mocks = vi.hoisted(() => {
+  const { writable, derived } = require('svelte/store');
+
+  const mockServers = writable([]);
+  const mockLoading = writable(false);
+
+  const mockMcpRuntimeStore = derived(
+    [mockServers, mockLoading],
+    ([$servers, $loading]: [any[], boolean]) => ({
+      servers: $servers,
+      tools: [],
+      loading: $loading,
+      error: null,
+      initialized: true,
+    }),
+  );
+
+  return {
+    mockServers,
+    mockLoading,
+    mockMcpRuntimeStore,
+    mockGetMcpCatalog: vi.fn(),
+    mockGetMcpClients: vi.fn(),
+    mockGetMcpStatus: vi.fn(),
+    mockGetMcpClientPermissions: vi.fn(),
+    mockConfigureMcp: vi.fn(),
+    mockConfigureCustomMcp: vi.fn(),
+    mockResetMcpConfig: vi.fn(),
+    mockUpdateMcpClientPermissions: vi.fn(),
+    mockRefresh: vi.fn(),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+vi.mock('$lib/api/client', () => ({
+  getMcpCatalog: mocks.mockGetMcpCatalog,
+  getMcpClients: mocks.mockGetMcpClients,
+  getMcpStatus: mocks.mockGetMcpStatus,
+  getMcpClientPermissions: mocks.mockGetMcpClientPermissions,
+  configureMcp: mocks.mockConfigureMcp,
+  configureCustomMcp: mocks.mockConfigureCustomMcp,
+  resetMcpConfig: mocks.mockResetMcpConfig,
+  updateMcpClientPermissions: mocks.mockUpdateMcpClientPermissions,
+  // Also needed by MCPToolTester (child component, rendered even if not tested)
+  getMcpTools: vi.fn().mockResolvedValue({ tools: [] }),
+  testMcpTool: vi.fn(),
+}));
+
+vi.mock('$lib/stores/mcp', () => ({
+  mcpRuntimeStore: mocks.mockMcpRuntimeStore,
+  mcpRuntimeActions: {
+    refresh: mocks.mockRefresh,
+    ensureLoaded: vi.fn(),
+    startServer: vi.fn(),
+    stopServer: vi.fn(),
+    restartServer: vi.fn(),
+    removeServer: vi.fn(),
+    removeTool: vi.fn(),
+    clearError: vi.fn(),
+  },
+}));
+
+// MCPToolTester has its own heavy dependencies — stub it with a no-op Svelte 5 component.
+vi.mock('./MCPToolTester.svelte', () => ({
+  default: function MCPToolTester() {},
+}));
+
+import MCPServersPage from './MCPServersPage.svelte';
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+const CATALOG_RESPONSE = {
+  version: '1.0',
+  updated: '2026-01-01',
+  servers: [
+    {
+      id: 'brave-search',
+      name: 'Brave Search',
+      description: 'Web search via Brave',
+      category: 'search',
+      website: 'https://brave.com',
+      install_method: 'npx',
+      command: 'npx',
+      args: ['-y', '@anthropic/mcp-brave-search'],
+      env_vars: [],
+      user_args: [],
+      tags: ['search'],
+    },
+  ],
+};
+
+const CLIENTS_RESPONSE = {
+  clients: [
+    {
+      id: 'cursor',
+      label: 'Cursor',
+      config_path: '/home/user/.cursor/mcp.json',
+      supports_apply: true,
+      exists: true,
+    },
+  ],
+};
+
+const STATUS_RESPONSE = {
+  client: 'cursor',
+  path: '/home/user/.cursor/mcp.json',
+  configured: {},
+  settings: {},
+  count: 0,
+};
+
+const PERMISSIONS_RESPONSE = {
+  client: 'cursor',
+  path: '/home/user/.cursor/mcp.json',
+  servers: {},
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Set up default mock return values so onMount succeeds and the loading state clears. */
+function setupDefaultMocks() {
+  mocks.mockGetMcpCatalog.mockResolvedValue(CATALOG_RESPONSE);
+  mocks.mockGetMcpClients.mockResolvedValue(CLIENTS_RESPONSE);
+  mocks.mockGetMcpStatus.mockResolvedValue(STATUS_RESPONSE);
+  mocks.mockGetMcpClientPermissions.mockResolvedValue(PERMISSIONS_RESPONSE);
+  mocks.mockRefresh.mockResolvedValue(undefined);
+}
+
+/** Render the page and wait until the loading spinner is gone. */
+async function renderPage() {
+  const result = render(MCPServersPage);
+  await waitFor(() => {
+    expect(screen.queryByText('Loading MCP catalog and client status...')).toBeNull();
+  });
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('MCPServersPage — Phase 2 (Custom Server Form)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mockServers.set([]);
+    mocks.mockLoading.set(false);
+    setupDefaultMocks();
+  });
+
+  // =========================================================================
+  // Tab toggle
+  // =========================================================================
+  describe('tab toggle', () => {
+    it('defaults to catalog view with the Catalog tab active', async () => {
+      await renderPage();
+      expect(screen.getByText('Catalog Browser')).toBeInTheDocument();
+      // The search filter should be visible in catalog mode
+      expect(screen.getByPlaceholderText('Search by name, id, or tag')).toBeInTheDocument();
+    });
+
+    it('switches to custom form view when Custom tab is clicked', async () => {
+      await renderPage();
+      const customTab = screen.getByRole('button', { name: 'Custom' });
+      await fireEvent.click(customTab);
+
+      expect(screen.getByText('Add Custom Server')).toBeInTheDocument();
+      // The catalog search should be hidden
+      expect(screen.queryByPlaceholderText('Search by name, id, or tag')).toBeNull();
+    });
+
+    it('switches back to catalog when Catalog tab is clicked', async () => {
+      await renderPage();
+      // Go to custom
+      await fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
+      expect(screen.getByText('Add Custom Server')).toBeInTheDocument();
+
+      // Back to catalog
+      await fireEvent.click(screen.getByRole('button', { name: 'Catalog' }));
+      expect(screen.getByText('Catalog Browser')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('Search by name, id, or tag')).toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Custom form rendering
+  // =========================================================================
+  describe('custom form fields', () => {
+    it('renders all required form fields', async () => {
+      await renderPage();
+      await fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
+
+      expect(screen.getByText('Server ID *')).toBeInTheDocument();
+      expect(screen.getByText('Command *')).toBeInTheDocument();
+      expect(screen.getByText('Arguments')).toBeInTheDocument();
+      expect(screen.getByText('Environment Variables')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('my-custom-server')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('npx, uvx, node, python ...')).toBeInTheDocument();
+    });
+
+    it('renders one empty argument row by default', async () => {
+      await renderPage();
+      await fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
+
+      const argInput = screen.getByPlaceholderText('e.g. -y, @modelcontextprotocol/server-github');
+      expect(argInput).toBeInTheDocument();
+      expect((argInput as HTMLInputElement).value).toBe('');
+    });
+
+    it('renders one empty env var row by default', async () => {
+      await renderPage();
+      await fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
+
+      expect(screen.getByPlaceholderText('KEY')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('value')).toBeInTheDocument();
+    });
+
+    it('adds an argument row when the add button is clicked', async () => {
+      await renderPage();
+      await fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
+
+      const addBtn = screen.getByTitle('Add argument');
+      await fireEvent.click(addBtn);
+
+      const argInputs = screen.getAllByPlaceholderText('e.g. -y, @modelcontextprotocol/server-github');
+      expect(argInputs).toHaveLength(2);
+    });
+
+    it('adds an env var row when the add button is clicked', async () => {
+      await renderPage();
+      await fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
+
+      const addBtn = screen.getByTitle('Add env var');
+      await fireEvent.click(addBtn);
+
+      const keyInputs = screen.getAllByPlaceholderText('KEY');
+      expect(keyInputs).toHaveLength(2);
+    });
+
+    it('removes an argument row when the remove button is clicked', async () => {
+      await renderPage();
+      await fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
+
+      // Add a second row first
+      await fireEvent.click(screen.getByTitle('Add argument'));
+      expect(screen.getAllByPlaceholderText('e.g. -y, @modelcontextprotocol/server-github')).toHaveLength(2);
+
+      // Remove the first one
+      const removeBtns = screen.getAllByTitle('Remove argument');
+      await fireEvent.click(removeBtns[0]);
+
+      // One row should remain (minimum of 1)
+      expect(screen.getAllByPlaceholderText('e.g. -y, @modelcontextprotocol/server-github')).toHaveLength(1);
+    });
+
+    it('removes an env var row when the remove button is clicked', async () => {
+      await renderPage();
+      await fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
+
+      // Add a second row
+      await fireEvent.click(screen.getByTitle('Add env var'));
+      expect(screen.getAllByPlaceholderText('KEY')).toHaveLength(2);
+
+      // Remove the first
+      const removeBtns = screen.getAllByTitle('Remove env var');
+      await fireEvent.click(removeBtns[0]);
+
+      expect(screen.getAllByPlaceholderText('KEY')).toHaveLength(1);
+    });
+  });
+
+  // =========================================================================
+  // Form validation
+  // =========================================================================
+  describe('form validation', () => {
+    it('shows error when server ID is empty', async () => {
+      await renderPage();
+      await fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
+
+      // Click Preview without filling anything
+      const previewBtn = screen.getByRole('button', { name: 'Preview config' });
+      await fireEvent.click(previewBtn);
+
+      expect(screen.getByText('Server ID is required.')).toBeInTheDocument();
+      expect(mocks.mockConfigureCustomMcp).not.toHaveBeenCalled();
+    });
+
+    it('shows error when server ID has invalid format', async () => {
+      await renderPage();
+      await fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
+
+      const serverIdInput = screen.getByPlaceholderText('my-custom-server');
+      await fireEvent.input(serverIdInput, { target: { value: 'Invalid Name!' } });
+
+      const cmdInput = screen.getByPlaceholderText('npx, uvx, node, python ...');
+      await fireEvent.input(cmdInput, { target: { value: 'npx' } });
+
+      const previewBtn = screen.getByRole('button', { name: 'Preview config' });
+      await fireEvent.click(previewBtn);
+
+      expect(screen.getByText('Must be lowercase alphanumeric with hyphens (e.g. my-server).')).toBeInTheDocument();
+      expect(mocks.mockConfigureCustomMcp).not.toHaveBeenCalled();
+    });
+
+    it('shows error when command is empty', async () => {
+      await renderPage();
+      await fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
+
+      const serverIdInput = screen.getByPlaceholderText('my-custom-server');
+      await fireEvent.input(serverIdInput, { target: { value: 'my-server' } });
+
+      const previewBtn = screen.getByRole('button', { name: 'Preview config' });
+      await fireEvent.click(previewBtn);
+
+      expect(screen.getByText('Command is required.')).toBeInTheDocument();
+      expect(mocks.mockConfigureCustomMcp).not.toHaveBeenCalled();
+    });
+
+    it('clears validation errors on successful submission', async () => {
+      mocks.mockConfigureCustomMcp.mockResolvedValue({
+        applied: false,
+        config: { mcpServers: { 'my-server': { command: 'npx' } } },
+        commands: [],
+        path: null,
+        warnings: [],
+      });
+
+      await renderPage();
+      await fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
+
+      // First trigger a validation error
+      await fireEvent.click(screen.getByRole('button', { name: 'Preview config' }));
+      expect(screen.getByText('Server ID is required.')).toBeInTheDocument();
+
+      // Now fill in valid data and submit
+      await fireEvent.input(screen.getByPlaceholderText('my-custom-server'), { target: { value: 'my-server' } });
+      await fireEvent.input(screen.getByPlaceholderText('npx, uvx, node, python ...'), { target: { value: 'npx' } });
+      await fireEvent.click(screen.getByRole('button', { name: 'Preview config' }));
+
+      await waitFor(() => {
+        expect(screen.queryByText('Server ID is required.')).toBeNull();
+      });
+    });
+  });
+
+  // =========================================================================
+  // API wiring
+  // =========================================================================
+  describe('API integration', () => {
+    it('calls configureCustomMcp with apply=false on preview', async () => {
+      mocks.mockConfigureCustomMcp.mockResolvedValue({
+        applied: false,
+        config: { mcpServers: { 'my-server': { command: 'npx', args: ['-y', 'my-pkg'] } } },
+        commands: [],
+        path: null,
+        warnings: [],
+      });
+
+      await renderPage();
+      await fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
+
+      await fireEvent.input(screen.getByPlaceholderText('my-custom-server'), { target: { value: 'my-server' } });
+      await fireEvent.input(screen.getByPlaceholderText('npx, uvx, node, python ...'), { target: { value: 'npx' } });
+
+      // Add an argument
+      const argInput = screen.getByPlaceholderText('e.g. -y, @modelcontextprotocol/server-github');
+      await fireEvent.input(argInput, { target: { value: '-y my-pkg' } });
+
+      await fireEvent.click(screen.getByRole('button', { name: 'Preview config' }));
+
+      await waitFor(() => {
+        expect(mocks.mockConfigureCustomMcp).toHaveBeenCalledWith(
+          expect.objectContaining({
+            server_id: 'my-server',
+            command: 'npx',
+            args: ['-y my-pkg'],
+            client: 'cursor',
+            apply: false,
+          }),
+        );
+      });
+    });
+
+    it('shows preview status message after successful preview', async () => {
+      mocks.mockConfigureCustomMcp.mockResolvedValue({
+        applied: false,
+        config: { mcpServers: { 'my-server': { command: 'npx' } } },
+        commands: [],
+        path: null,
+        warnings: [],
+      });
+
+      await renderPage();
+      await fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
+
+      await fireEvent.input(screen.getByPlaceholderText('my-custom-server'), { target: { value: 'my-server' } });
+      await fireEvent.input(screen.getByPlaceholderText('npx, uvx, node, python ...'), { target: { value: 'npx' } });
+      await fireEvent.click(screen.getByRole('button', { name: 'Preview config' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Custom server preview updated.')).toBeInTheDocument();
+      });
+    });
+
+    it('sends env vars in the payload', async () => {
+      mocks.mockConfigureCustomMcp.mockResolvedValue({
+        applied: false,
+        config: {},
+        commands: [],
+        path: null,
+        warnings: [],
+      });
+
+      await renderPage();
+      await fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
+
+      await fireEvent.input(screen.getByPlaceholderText('my-custom-server'), { target: { value: 'my-server' } });
+      await fireEvent.input(screen.getByPlaceholderText('npx, uvx, node, python ...'), { target: { value: 'node' } });
+      await fireEvent.input(screen.getByPlaceholderText('KEY'), { target: { value: 'MY_TOKEN' } });
+      await fireEvent.input(screen.getByPlaceholderText('value'), { target: { value: 'secret123' } });
+
+      await fireEvent.click(screen.getByRole('button', { name: 'Preview config' }));
+
+      await waitFor(() => {
+        expect(mocks.mockConfigureCustomMcp).toHaveBeenCalledWith(
+          expect.objectContaining({
+            env: { MY_TOKEN: 'secret123' },
+          }),
+        );
+      });
+    });
+
+    it('shows error message when API call fails', async () => {
+      mocks.mockConfigureCustomMcp.mockRejectedValue(new Error('Network error'));
+
+      await renderPage();
+      await fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
+
+      await fireEvent.input(screen.getByPlaceholderText('my-custom-server'), { target: { value: 'my-server' } });
+      await fireEvent.input(screen.getByPlaceholderText('npx, uvx, node, python ...'), { target: { value: 'npx' } });
+      await fireEvent.click(screen.getByRole('button', { name: 'Preview config' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Network error')).toBeInTheDocument();
+      });
+    });
+  });
+
+  // =========================================================================
+  // Catalog / custom badges in status panel
+  // =========================================================================
+  describe('catalog/custom status badges', () => {
+    it('shows "catalog" badge for a server that matches the catalog', async () => {
+      mocks.mockGetMcpStatus.mockResolvedValue({
+        client: 'cursor',
+        path: '/home/user/.cursor/mcp.json',
+        configured: {
+          'brave-search': { command: 'npx', args: ['-y', '@anthropic/mcp-brave-search'] },
+        },
+        settings: {},
+        count: 1,
+      });
+
+      await renderPage();
+
+      expect(screen.getByText('brave-search')).toBeInTheDocument();
+      expect(screen.getByText('catalog')).toBeInTheDocument();
+      expect(screen.queryByText('custom')).toBeNull();
+    });
+
+    it('shows "custom" badge for a server not in the catalog', async () => {
+      mocks.mockGetMcpStatus.mockResolvedValue({
+        client: 'cursor',
+        path: '/home/user/.cursor/mcp.json',
+        configured: {
+          'my-private-server': { command: 'node', args: ['server.js'] },
+        },
+        settings: {},
+        count: 1,
+      });
+
+      await renderPage();
+
+      expect(screen.getByText('my-private-server')).toBeInTheDocument();
+      expect(screen.getByText('custom')).toBeInTheDocument();
+      expect(screen.queryByText('catalog')).toBeNull();
+    });
+
+    it('shows both badges when catalog and custom servers are configured', async () => {
+      mocks.mockGetMcpStatus.mockResolvedValue({
+        client: 'cursor',
+        path: '/home/user/.cursor/mcp.json',
+        configured: {
+          'brave-search': { command: 'npx', args: [] },
+          'my-private-server': { command: 'node', args: [] },
+        },
+        settings: {},
+        count: 2,
+      });
+
+      await renderPage();
+
+      expect(screen.getByText('brave-search')).toBeInTheDocument();
+      expect(screen.getByText('my-private-server')).toBeInTheDocument();
+      expect(screen.getByText('catalog')).toBeInTheDocument();
+      expect(screen.getByText('custom')).toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Preview panel context awareness
+  // =========================================================================
+  describe('preview panel', () => {
+    it('shows catalog-specific placeholder in catalog mode', async () => {
+      await renderPage();
+      expect(screen.getByText('Select one or more servers, then click "Preview config".')).toBeInTheDocument();
+    });
+
+    it('shows custom-specific placeholder in custom mode', async () => {
+      await renderPage();
+      await fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
+      expect(screen.getByText('Fill in the custom server form, then click "Preview config".')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/lib/components/mcp/MCPServersPage.test.ts
+++ b/frontend/src/lib/components/mcp/MCPServersPage.test.ts
@@ -201,7 +201,7 @@ describe('MCPServersPage — Phase 2 (Custom Server Form)', () => {
 
       expect(screen.getByText('Server ID *')).toBeInTheDocument();
       expect(screen.getByText('Command *')).toBeInTheDocument();
-      expect(screen.getByText('Arguments')).toBeInTheDocument();
+      expect(screen.getByText('Arguments (one per row)')).toBeInTheDocument();
       expect(screen.getByText('Environment Variables')).toBeInTheDocument();
       expect(screen.getByPlaceholderText('my-custom-server')).toBeInTheDocument();
       expect(screen.getByPlaceholderText('npx, uvx, node, python ...')).toBeInTheDocument();
@@ -211,7 +211,7 @@ describe('MCPServersPage — Phase 2 (Custom Server Form)', () => {
       await renderPage();
       await fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
 
-      const argInput = screen.getByPlaceholderText('e.g. -y, @modelcontextprotocol/server-github');
+      const argInput = screen.getByPlaceholderText('e.g. -y');
       expect(argInput).toBeInTheDocument();
       expect((argInput as HTMLInputElement).value).toBe('');
     });
@@ -231,7 +231,7 @@ describe('MCPServersPage — Phase 2 (Custom Server Form)', () => {
       const addBtn = screen.getByTitle('Add argument');
       await fireEvent.click(addBtn);
 
-      const argInputs = screen.getAllByPlaceholderText('e.g. -y, @modelcontextprotocol/server-github');
+      const argInputs = screen.getAllByPlaceholderText('e.g. -y');
       expect(argInputs).toHaveLength(2);
     });
 
@@ -252,14 +252,14 @@ describe('MCPServersPage — Phase 2 (Custom Server Form)', () => {
 
       // Add a second row first
       await fireEvent.click(screen.getByTitle('Add argument'));
-      expect(screen.getAllByPlaceholderText('e.g. -y, @modelcontextprotocol/server-github')).toHaveLength(2);
+      expect(screen.getAllByPlaceholderText('e.g. -y')).toHaveLength(2);
 
       // Remove the first one
       const removeBtns = screen.getAllByTitle('Remove argument');
       await fireEvent.click(removeBtns[0]);
 
       // One row should remain (minimum of 1)
-      expect(screen.getAllByPlaceholderText('e.g. -y, @modelcontextprotocol/server-github')).toHaveLength(1);
+      expect(screen.getAllByPlaceholderText('e.g. -y')).toHaveLength(1);
     });
 
     it('removes an env var row when the remove button is clicked', async () => {
@@ -371,9 +371,12 @@ describe('MCPServersPage — Phase 2 (Custom Server Form)', () => {
       await fireEvent.input(screen.getByPlaceholderText('my-custom-server'), { target: { value: 'my-server' } });
       await fireEvent.input(screen.getByPlaceholderText('npx, uvx, node, python ...'), { target: { value: 'npx' } });
 
-      // Add an argument
-      const argInput = screen.getByPlaceholderText('e.g. -y, @modelcontextprotocol/server-github');
-      await fireEvent.input(argInput, { target: { value: '-y my-pkg' } });
+      // Fill in the first arg row and add a second
+      const argInput = screen.getByPlaceholderText('e.g. -y');
+      await fireEvent.input(argInput, { target: { value: '-y' } });
+      await fireEvent.click(screen.getByTitle('Add argument'));
+      const argInputs = screen.getAllByPlaceholderText('e.g. -y');
+      await fireEvent.input(argInputs[1], { target: { value: 'my-pkg' } });
 
       await fireEvent.click(screen.getByRole('button', { name: 'Preview config' }));
 
@@ -382,7 +385,7 @@ describe('MCPServersPage — Phase 2 (Custom Server Form)', () => {
           expect.objectContaining({
             server_id: 'my-server',
             command: 'npx',
-            args: ['-y my-pkg'],
+            args: ['-y', 'my-pkg'],
             client: 'cursor',
             apply: false,
           }),


### PR DESCRIPTION
feat(MCP) add custom server form

Closes #65

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the custom server form (Phase 2 of the MCP feature), letting users define non-catalog MCP servers by providing an ID, command, per-row arguments, and environment variables, with preview and apply flows and a tab toggle between the catalog browser and the new form. All four issues from the previous review round (misleading arg placeholder, plain-text env values, stale preview on tab switch, and the broken single-arg test) are addressed.

- **P1**: `generateCustomConfig` resets the form when the `apply` parameter is `true` rather than when `preview.applied` is `true`; if the backend returns `{ applied: false }` after a silent write failure, the user's form data is destroyed and the status message says \"Custom server preview updated.\" — change `if (apply)` to `if (preview.applied)` on line 548.
- **P2**: `statusMessage` is not cleared at the start of a new API call, so a stale success banner can coexist with a new error.
- **P2**: No test exercises the `apply=true` path (form reset, applied status message, `refreshStatus` call).

<h3>Confidence Score: 3/5</h3>

Not safe to merge until the apply-vs-preview.applied guard is fixed — it can silently discard form data.

One genuine P1 defect: the form is irreversibly reset whenever `apply=true` regardless of whether the backend confirms `applied=true`, causing silent data loss and a misleading status message on any backend write failure. The stale `statusMessage` issue compounds the UX confusion. Both should be addressed before merge.

frontend/src/lib/components/mcp/MCPServersPage.svelte — specifically the `generateCustomConfig` function around line 548.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/src/lib/components/mcp/MCPServersPage.svelte | Adds custom server form with view-mode toggle, per-row arg/env inputs, validation, and preview/apply flow; form reset is conditioned on the caller's intent (`apply` param) rather than the backend's actual result (`preview.applied`), which can silently lose form data. |
| frontend/src/lib/components/mcp/MCPServersPage.test.ts | Adds thorough Phase 2 tests covering tab toggle, form rendering, validation, env-var payload, and status badges; missing coverage for the `apply=true` flow (form reset, applied status message, refreshStatus call). |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: frontend/src/lib/components/mcp/MCPServersPage.svelte
Line: 548-551

Comment:
**Form reset conditioned on user intent, not backend result**

`resetCustomForm()` is called whenever `apply` is `true` (the caller's intent), not when `preview.applied` is `true` (what the backend actually did). If the backend succeeds the HTTP call but returns `{ applied: false }` — e.g. due to a permissions error or a write failure handled silently — the user loses all form data and sees "Custom server preview updated." instead of any indication that the apply failed.

```suggestion
      if (preview.applied) {
        resetCustomForm();
        await refreshStatus();
      }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: frontend/src/lib/components/mcp/MCPServersPage.svelte
Line: 527-530

Comment:
**Stale `statusMessage` not cleared on new API call**

`error` and `copyMessage` are cleared at the top of the try block, but `statusMessage` is not. If a previous call left a success message and the subsequent call throws, both the old success text and the new error are visible simultaneously. Adding `statusMessage = '';` here keeps the panel consistent.

```suggestion
      actionLoading = true;
      error = null;
      copyMessage = '';
      statusMessage = '';
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: frontend/src/lib/components/mcp/MCPServersPage.test.ts
Line: 358-458

Comment:
**No test for the `apply=true` path**

The API integration tests only exercise `generateCustomConfig(false)` (preview). The `apply=true` path — which calls `resetCustomForm()` and `refreshStatus()` — is completely untested. A regression there (e.g. form not resetting, `refreshStatus` not called, or wrong status message when `preview.applied` is `false`) would be invisible. Consider adding a test that clicks "Apply config", asserts `configureCustomMcp` is called with `apply: true`, and verifies the form fields are cleared and the status message reads the applied text.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(MCP): fixes for PR feedback on PR 70..."](https://github.com/bytes0211/stratifyai/commit/0601bb25cd081b255b23c463426db993f46e0a2d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28071242)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->