### PR TITLE
PR - Custom MCP Phase 4: Edit and Delete Custom Servers

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -50,6 +50,7 @@ from stratifyai.mcp_catalog import (
     detect_client_config_path,
     get_configured_servers,
     get_mcp_client_settings,
+    remove_server_from_config,
     remove_servers_from_config,
     validate_prerequisites,
     write_client_config,
@@ -3125,6 +3126,74 @@ async def add_custom_mcp_server(
         raise HTTPException(status_code=400, detail=sanitize_error(str(exc))) from exc
 
 
+class MCPCustomServerUpdateRequest(BaseModel):
+    """Request model for editing an existing custom MCP server."""
+
+    command: str | None = None
+    args: list[str] | None = None
+    env: dict[str, str] | None = None
+    client: str
+    enabled: bool | None = None
+    auto_start: bool | None = None
+    project_root: str | None = None
+    output_path: str | None = None
+
+    @field_validator("client")
+    @classmethod
+    def validate_client(cls, value: str) -> str:
+        """Validate the target client identifier."""
+        allowed = {"claude-desktop", "claude-code", "cursor", "vscode"}
+        if value not in allowed:
+            raise ValueError(f"client must be one of: {', '.join(sorted(allowed))}")
+        return value
+
+    @field_validator("command")
+    @classmethod
+    def validate_command(cls, value: str | None) -> str | None:
+        """Validate command is free of shell metacharacters when provided."""
+        if value is None:
+            return value
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("command must be non-empty when provided")
+        if _SHELL_METACHAR_RE.search(stripped):
+            raise ValueError(
+                "command must not contain shell metacharacters "
+                "(;, |, &, $(), or backticks)"
+            )
+        return stripped
+
+    @field_validator("env")
+    @classmethod
+    def validate_env(cls, value: dict[str, str] | None) -> dict[str, str] | None:
+        """Reject env var names containing '=' or whitespace."""
+        if value is None:
+            return value
+        for key in value:
+            if "=" in key:
+                raise ValueError(f"env var name '{key}' must not contain '='")
+            if _re_module.search(r"\s", key):
+                raise ValueError(f"env var name '{key}' must not contain whitespace")
+        return value
+
+
+class MCPCustomServerDeleteRequest(BaseModel):
+    """Query model for deleting a custom MCP server."""
+
+    client: str
+    project_root: str | None = None
+    output_path: str | None = None
+
+    @field_validator("client")
+    @classmethod
+    def validate_client(cls, value: str) -> str:
+        """Validate the target client identifier."""
+        allowed = {"claude-desktop", "claude-code", "cursor", "vscode"}
+        if value not in allowed:
+            raise ValueError(f"client must be one of: {', '.join(sorted(allowed))}")
+        return value
+
+
 def _mask_env_in_config(config: dict[str, Any], client: str) -> dict[str, Any]:
     """Return a deep copy of the config with env values replaced by '***'."""
     import copy
@@ -3140,6 +3209,135 @@ def _mask_env_in_config(config: dict[str, Any], client: str) -> dict[str, Any]:
             for key in env:
                 env[key] = "***"
     return masked
+
+
+@app.put("/api/mcp/custom/{server_id}")
+async def update_custom_mcp_server(
+    server_id: str,
+    payload: MCPCustomServerUpdateRequest,
+    _: None = Depends(verify_api_key),
+):
+    """Edit an existing custom MCP server in a client config file."""
+    try:
+        if payload.client == "claude-code":
+            raise ValueError(
+                "Claude Code servers cannot be edited via config file. "
+                "Use `claude mcp remove` then `claude mcp add` instead."
+            )
+
+        _, existing_servers = get_configured_servers(
+            client=payload.client,
+            project_root=payload.project_root,
+            output_path=payload.output_path,
+        )
+
+        if server_id not in existing_servers:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Server '{server_id}' not found in {payload.client} config.",
+            )
+
+        current = existing_servers[server_id]
+        if not isinstance(current, dict):
+            current = {}
+
+        # Merge only the fields that were explicitly provided.
+        updated: dict[str, Any] = dict(current)
+        if payload.command is not None:
+            updated["command"] = payload.command
+        if payload.args is not None:
+            updated["args"] = payload.args
+        if payload.env is not None:
+            updated["env"] = payload.env
+
+        # Build the config dict in the client-expected format.
+        config: dict[str, Any]
+        if payload.client == "vscode":
+            config = {"mcp": {"servers": {server_id: updated}}}
+        else:
+            config = {"mcpServers": {server_id: updated}}
+
+        written = write_client_config(
+            client=payload.client,
+            config=config,
+            project_root=payload.project_root,
+            output_path=payload.output_path,
+        )
+
+        # Update permission metadata if enabled/auto_start changed.
+        settings_updates: dict[str, Any] = {}
+        if payload.enabled is not None:
+            settings_updates["enabled"] = payload.enabled
+        if payload.auto_start is not None:
+            settings_updates["auto_start"] = payload.auto_start
+        if settings_updates:
+            write_mcp_client_settings(
+                client=payload.client,
+                settings={"servers": {server_id: settings_updates}},
+                project_root=payload.project_root,
+                output_path=payload.output_path,
+            )
+
+        global _mcp_chat_engine
+        if _mcp_chat_engine is not None:
+            await get_mcp_chat_engine(refresh=True)
+
+        return {
+            "server_id": server_id,
+            "config": updated,
+            "path": str(written),
+        }
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=sanitize_error(str(exc))) from exc
+
+
+@app.delete("/api/mcp/custom/{server_id}")
+async def delete_custom_mcp_server(
+    server_id: str,
+    client: str,
+    project_root: str | None = None,
+    output_path: str | None = None,
+    _: None = Depends(verify_api_key),
+):
+    """Remove a custom MCP server from a client config file."""
+    try:
+        # Validate client value.
+        allowed_clients = {"claude-desktop", "claude-code", "cursor", "vscode"}
+        if client not in allowed_clients:
+            raise ValueError(
+                f"client must be one of: {', '.join(sorted(allowed_clients))}"
+            )
+
+        if client == "claude-code":
+            raise ValueError(
+                "Claude Code servers cannot be removed via config file. "
+                "Use `claude mcp remove <server-id>` instead."
+            )
+
+        path, removed = remove_server_from_config(
+            client=client,
+            server_id=server_id,
+            project_root=project_root,
+            output_path=output_path,
+        )
+
+        if not removed:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Server '{server_id}' not found in {client} config.",
+            )
+
+        global _mcp_chat_engine
+        if _mcp_chat_engine is not None:
+            await get_mcp_chat_engine(refresh=True)
+
+        return {
+            "server_id": server_id,
+            "removed": True,
+            "path": str(path),
+        }
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=sanitize_error(str(exc))) from exc
 
 
 @app.post("/api/mcp/reset", response_model=MCPResetResponse)

--- a/api/main.py
+++ b/api/main.py
@@ -3177,23 +3177,6 @@ class MCPCustomServerUpdateRequest(BaseModel):
         return value
 
 
-class MCPCustomServerDeleteRequest(BaseModel):
-    """Query model for deleting a custom MCP server."""
-
-    client: str
-    project_root: str | None = None
-    output_path: str | None = None
-
-    @field_validator("client")
-    @classmethod
-    def validate_client(cls, value: str) -> str:
-        """Validate the target client identifier."""
-        allowed = {"claude-desktop", "claude-code", "cursor", "vscode"}
-        if value not in allowed:
-            raise ValueError(f"client must be one of: {', '.join(sorted(allowed))}")
-        return value
-
-
 def _mask_env_in_config(config: dict[str, Any], client: str) -> dict[str, Any]:
     """Return a deep copy of the config with env values replaced by '***'."""
     import copy
@@ -3242,7 +3225,9 @@ async def update_custom_mcp_server(
             current = {}
 
         # Merge only the fields that were explicitly provided.
-        updated: dict[str, Any] = dict(current)
+        import copy
+
+        updated: dict[str, Any] = copy.deepcopy(current)
         if payload.command is not None:
             updated["command"] = payload.command
         if payload.args is not None:

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -15,6 +15,9 @@ import type {
   McpConfigureRequest,
   McpConfigureResponse,
   McpCustomServerRequest,
+  McpCustomServerUpdateRequest,
+  McpCustomServerUpdateResponse,
+  McpCustomServerDeleteResponse,
   McpResetRequest,
   McpResetResponse,
   McpToolsResponse,
@@ -135,6 +138,38 @@ export async function configureCustomMcp(req: McpCustomServerRequest): Promise<M
     method: 'POST',
     body: JSON.stringify(req),
   });
+}
+
+export async function updateCustomMcp(
+  serverId: string,
+  req: McpCustomServerUpdateRequest
+): Promise<McpCustomServerUpdateResponse> {
+  return request<McpCustomServerUpdateResponse>(
+    `/mcp/custom/${encodeURIComponent(serverId)}`,
+    {
+      method: 'PUT',
+      body: JSON.stringify(req),
+    }
+  );
+}
+
+export async function deleteCustomMcp(
+  serverId: string,
+  client: McpConfigureRequest['client'],
+  projectRoot?: string,
+  outputPath?: string
+): Promise<McpCustomServerDeleteResponse> {
+  const params = new URLSearchParams({ client });
+  if (projectRoot) {
+    params.set('project_root', projectRoot);
+  }
+  if (outputPath) {
+    params.set('output_path', outputPath);
+  }
+  return request<McpCustomServerDeleteResponse>(
+    `/mcp/custom/${encodeURIComponent(serverId)}?${params.toString()}`,
+    { method: 'DELETE' }
+  );
 }
 
 export async function resetMcpConfig(req: McpResetRequest): Promise<McpResetResponse> {

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -286,6 +286,29 @@ export interface McpCustomServerRequest {
   apply?: boolean;
 }
 
+export interface McpCustomServerUpdateRequest {
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  client: 'claude-desktop' | 'claude-code' | 'cursor' | 'vscode';
+  enabled?: boolean;
+  auto_start?: boolean;
+  project_root?: string;
+  output_path?: string;
+}
+
+export interface McpCustomServerUpdateResponse {
+  server_id: string;
+  config: Record<string, unknown>;
+  path: string;
+}
+
+export interface McpCustomServerDeleteResponse {
+  server_id: string;
+  removed: boolean;
+  path: string;
+}
+
 export interface McpResetRequest {
   client: 'claude-desktop' | 'claude-code' | 'cursor' | 'vscode';
   server_ids?: string[];

--- a/frontend/src/lib/components/mcp/MCPServersPage.svelte
+++ b/frontend/src/lib/components/mcp/MCPServersPage.svelte
@@ -253,8 +253,8 @@
       await updateCustomMcp(editingServerId, {
         client: selectedClient,
         command: editCommand || undefined,
-        args: editArgs.length > 0 ? editArgs : undefined,
-        env: Object.keys(envObj).length > 0 ? envObj : undefined,
+        args: editArgs,
+        env: Object.keys(envObj).length > 0 ? envObj : {},
         project_root: projectRoot || undefined,
       });
       statusMessage = `Server "${editingServerId}" updated.`;

--- a/frontend/src/lib/components/mcp/MCPServersPage.svelte
+++ b/frontend/src/lib/components/mcp/MCPServersPage.svelte
@@ -2,11 +2,13 @@
   import { onMount } from 'svelte';
   import {
     configureMcp,
+    deleteCustomMcp,
     getMcpCatalog,
     getMcpClientPermissions,
     getMcpClients,
     getMcpStatus,
     resetMcpConfig,
+    updateCustomMcp,
     updateMcpClientPermissions,
   } from '$lib/api/client';
   import type {
@@ -29,6 +31,7 @@
     CheckCircle2,
     Copy,
     Download,
+    Pencil,
     Play,
     PlugZap,
     Power,
@@ -39,6 +42,7 @@
     Square,
     Trash2,
     Wrench,
+    X,
   } from 'lucide-svelte';
 
   let catalog: McpCatalogResponse | null = null;
@@ -71,6 +75,12 @@
   let error: string | null = null;
   let statusMessage = '';
   let copyMessage = '';
+
+  // --- Phase 4: Edit custom server state ---
+  let editingServerId: string | null = null;
+  let editCommand = '';
+  let editArgs: string[] = [];
+  let editEnvPairs: Array<{ key: string; value: string }> = [];
 
   onMount(() => {
     void initialize();
@@ -186,6 +196,96 @@
       await refreshStatus();
     } catch (err) {
       error = err instanceof Error ? err.message : `Failed to remove ${serverId}`;
+    } finally {
+      runtimeActionLoading = '';
+    }
+  }
+
+  // --- Phase 4: Edit / delete helpers for custom servers ---
+
+  function isCatalogServer(serverId: string): boolean {
+    return catalog?.servers.some((item) => item.id === serverId) ?? false;
+  }
+
+  function startEditing(serverId: string) {
+    const serverConfig = statusData?.configured?.[serverId];
+    editingServerId = serverId;
+    editCommand = serverConfig?.command ?? '';
+    editArgs = [...(serverConfig?.args ?? [])];
+    const envRecord = serverConfig?.env ?? {};
+    editEnvPairs = Object.entries(envRecord).map(([key, value]) => ({ key, value }));
+  }
+
+  function cancelEditing() {
+    editingServerId = null;
+    editCommand = '';
+    editArgs = [];
+    editEnvPairs = [];
+  }
+
+  function addEditArg() {
+    editArgs = [...editArgs, ''];
+  }
+
+  function removeEditArg(index: number) {
+    editArgs = editArgs.filter((_, i) => i !== index);
+  }
+
+  function addEditEnvPair() {
+    editEnvPairs = [...editEnvPairs, { key: '', value: '' }];
+  }
+
+  function removeEditEnvPair(index: number) {
+    editEnvPairs = editEnvPairs.filter((_, i) => i !== index);
+  }
+
+  async function submitEdit() {
+    if (!editingServerId) return;
+    try {
+      runtimeActionLoading = `${editingServerId}:edit`;
+      error = null;
+      const envObj: Record<string, string> = {};
+      for (const pair of editEnvPairs) {
+        if (pair.key.trim()) {
+          envObj[pair.key.trim()] = pair.value;
+        }
+      }
+      await updateCustomMcp(editingServerId, {
+        client: selectedClient,
+        command: editCommand || undefined,
+        args: editArgs.length > 0 ? editArgs : undefined,
+        env: Object.keys(envObj).length > 0 ? envObj : undefined,
+        project_root: projectRoot || undefined,
+      });
+      statusMessage = `Server "${editingServerId}" updated.`;
+      cancelEditing();
+      await refreshStatus();
+    } catch (err) {
+      error = err instanceof Error ? err.message : `Failed to update ${editingServerId}`;
+    } finally {
+      runtimeActionLoading = '';
+    }
+  }
+
+  async function deleteServer(serverId: string) {
+    if (typeof window !== 'undefined' && !window.confirm(`Delete server "${serverId}" from ${selectedClient} config?`)) {
+      return;
+    }
+    try {
+      runtimeActionLoading = `${serverId}:delete`;
+      error = null;
+      await deleteCustomMcp(serverId, selectedClient, projectRoot || undefined);
+      if (editingServerId === serverId) {
+        cancelEditing();
+      }
+      selectedServerIds = selectedServerIds.filter((id) => id !== serverId);
+      if (selectedRuntimeTool.startsWith(`${serverId}.`)) {
+        selectedRuntimeTool = '';
+      }
+      statusMessage = `Deleted server "${serverId}" from ${selectedClient} config.`;
+      await refreshStatus();
+    } catch (err) {
+      error = err instanceof Error ? err.message : `Failed to delete ${serverId}`;
     } finally {
       runtimeActionLoading = '';
     }
@@ -538,10 +638,13 @@
 
         <p class="path-text">{statusData?.path ?? 'No config file path resolved for this client.'}</p>
 
-        {#if statusData && statusData.count > 0}
+      {#if statusData && statusData.count > 0}
           <div class="configured-list">
             {#each Object.keys(statusData.configured) as serverId}
               <span class="chip configured">{serverId}</span>
+              {#if !isCatalogServer(serverId)}
+                <span class="chip custom">custom</span>
+              {/if}
             {/each}
           </div>
         {:else}
@@ -725,50 +828,116 @@
               <div class="server-meta">
                 <span class="chip">{server.enabled ? 'enabled' : 'disabled'}</span>
                 <span class="chip">{server.auto_start ? 'auto-start' : 'manual start'}</span>
+                {#if isCatalogServer(server.server_id)}
+                  <span class="chip">catalog</span>
+                {:else}
+                  <span class="chip custom">custom</span>
+                {/if}
               </div>
 
               {#if server.error}
                 <p class="error-inline">{server.error}</p>
               {/if}
 
-              <div class="action-row secondary-actions">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  on:click={() => runServerAction(server.server_id, 'start')}
-                  disabled={runtimeActionLoading !== '' || !server.enabled || server.status === 'connected'}
-                >
-                  <Play size={14} />
-                  Start
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  on:click={() => runServerAction(server.server_id, 'stop')}
-                  disabled={runtimeActionLoading !== '' || server.status !== 'connected'}
-                >
-                  <Square size={14} />
-                  Stop
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  on:click={() => runServerAction(server.server_id, 'restart')}
-                  disabled={runtimeActionLoading !== '' || !server.enabled}
-                >
-                  <Power size={14} />
-                  Restart
-                </Button>
-                <Button
-                  variant="danger"
-                  size="sm"
-                  on:click={() => removeServer(server.server_id)}
-                  disabled={runtimeActionLoading !== ''}
-                >
-                  <Trash2 size={14} />
-                  Remove
-                </Button>
-              </div>
+              {#if editingServerId === server.server_id}
+                <div class="edit-form">
+                  <label>
+                    <span>Command</span>
+                    <input type="text" bind:value={editCommand} placeholder="e.g. node, python" />
+                  </label>
+
+                  <div class="edit-field-group">
+                    <span class="edit-field-label">Arguments</span>
+                    {#each editArgs as arg, i}
+                      <div class="edit-inline-row">
+                        <input type="text" bind:value={editArgs[i]} placeholder="arg" />
+                        <button class="icon-btn" on:click={() => removeEditArg(i)}><X size={14} /></button>
+                      </div>
+                    {/each}
+                    <button class="text-btn" on:click={addEditArg}>+ Add argument</button>
+                  </div>
+
+                  <div class="edit-field-group">
+                    <span class="edit-field-label">Environment variables</span>
+                    {#each editEnvPairs as pair, i}
+                      <div class="edit-inline-row">
+                        <input type="text" bind:value={editEnvPairs[i].key} placeholder="KEY" />
+                        <input type="text" bind:value={editEnvPairs[i].value} placeholder="value" />
+                        <button class="icon-btn" on:click={() => removeEditEnvPair(i)}><X size={14} /></button>
+                      </div>
+                    {/each}
+                    <button class="text-btn" on:click={addEditEnvPair}>+ Add env var</button>
+                  </div>
+
+                  <div class="action-row secondary-actions">
+                    <Button variant="primary" size="sm" on:click={submitEdit} loading={runtimeActionLoading === `${server.server_id}:edit`}>
+                      Save
+                    </Button>
+                    <Button variant="ghost" size="sm" on:click={cancelEditing}>
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              {:else}
+                <div class="action-row secondary-actions">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    on:click={() => runServerAction(server.server_id, 'start')}
+                    disabled={runtimeActionLoading !== '' || !server.enabled || server.status === 'connected'}
+                  >
+                    <Play size={14} />
+                    Start
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    on:click={() => runServerAction(server.server_id, 'stop')}
+                    disabled={runtimeActionLoading !== '' || server.status !== 'connected'}
+                  >
+                    <Square size={14} />
+                    Stop
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    on:click={() => runServerAction(server.server_id, 'restart')}
+                    disabled={runtimeActionLoading !== '' || !server.enabled}
+                  >
+                    <Power size={14} />
+                    Restart
+                  </Button>
+                  {#if !isCatalogServer(server.server_id)}
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      on:click={() => startEditing(server.server_id)}
+                      disabled={runtimeActionLoading !== ''}
+                    >
+                      <Pencil size={14} />
+                      Edit
+                    </Button>
+                    <Button
+                      variant="danger"
+                      size="sm"
+                      on:click={() => deleteServer(server.server_id)}
+                      disabled={runtimeActionLoading !== ''}
+                    >
+                      <Trash2 size={14} />
+                      Delete
+                    </Button>
+                  {/if}
+                  <Button
+                    variant="danger"
+                    size="sm"
+                    on:click={() => removeServer(server.server_id)}
+                    disabled={runtimeActionLoading !== ''}
+                  >
+                    <Trash2 size={14} />
+                    Remove
+                  </Button>
+                </div>
+              {/if}
             </article>
           {/each}
         </div>
@@ -1070,6 +1239,11 @@
     &.configured {
       background: rgba(16, 185, 129, 0.14);
       color: #10b981;
+    }
+
+    &.custom {
+      background: rgba(139, 92, 246, 0.14);
+      color: #8b5cf6;
     }
   }
 
@@ -1385,5 +1559,67 @@
     gap: $space-3;
     min-height: 280px;
     color: var(--text-secondary);
+  }
+
+  .edit-form {
+    display: flex;
+    flex-direction: column;
+    gap: $space-3;
+    border: 1px solid var(--bg-hover);
+    border-radius: $radius-lg;
+    padding: $space-3;
+    background: var(--bg-base);
+  }
+
+  .edit-field-group {
+    display: flex;
+    flex-direction: column;
+    gap: $space-2;
+  }
+
+  .edit-field-label {
+    font-size: $text-sm;
+    color: var(--text-secondary);
+  }
+
+  .edit-inline-row {
+    display: flex;
+    gap: $space-2;
+    align-items: center;
+
+    input {
+      flex: 1;
+    }
+  }
+
+  .icon-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: $space-1;
+    border: 1px solid var(--bg-hover);
+    border-radius: $radius-lg;
+    background: var(--bg-elevated);
+    color: var(--text-secondary);
+    cursor: pointer;
+
+    &:hover {
+      color: #ef4444;
+      border-color: #ef4444;
+    }
+  }
+
+  .text-btn {
+    border: none;
+    background: none;
+    color: var(--accent);
+    font-size: $text-sm;
+    cursor: pointer;
+    text-align: left;
+    padding: 0;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 </style>

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1050,3 +1050,223 @@ def test_add_custom_mcp_empty_env_value_warns():
     assert resp.status_code == 200
     body = resp.json()
     assert any("EMPTY_VAR" in w and "empty" in w for w in body["warnings"])
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — Edit and Delete Custom Servers
+# ---------------------------------------------------------------------------
+
+
+@patch.dict("os.environ", {"STRATIFYAI_API_KEY": "api-secret"})
+def test_update_custom_mcp_server_merges_changed_fields(tmp_path):
+    """PUT endpoint merges only the fields that are provided."""
+    import api.main as api_main
+    from api.main import app
+
+    config_path = tmp_path / ".cursor" / "mcp.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "my-server": {
+                        "command": "node",
+                        "args": ["old.js"],
+                        "env": {"KEY": "old"},
+                    },
+                    "other-server": {
+                        "command": "python",
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    original_engine = api_main._mcp_chat_engine
+    api_main._mcp_chat_engine = None
+    try:
+        client = TestClient(app)
+        headers = {"Authorization": "Bearer api-secret"}
+
+        resp = client.put(
+            "/api/mcp/custom/my-server",
+            json={
+                "client": "cursor",
+                "command": "deno",
+                "output_path": str(config_path),
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["server_id"] == "my-server"
+        # Command updated, args and env preserved from original config.
+        assert body["config"]["command"] == "deno"
+        assert body["config"]["args"] == ["old.js"]
+        assert body["config"]["env"] == {"KEY": "old"}
+
+        # Verify on disk: other-server is untouched.
+        written = json.loads(config_path.read_text(encoding="utf-8"))
+        assert written["mcpServers"]["other-server"]["command"] == "python"
+        assert written["mcpServers"]["my-server"]["command"] == "deno"
+    finally:
+        api_main._mcp_chat_engine = original_engine
+
+
+@patch.dict("os.environ", {"STRATIFYAI_API_KEY": "api-secret"})
+def test_update_custom_mcp_server_not_found_returns_404(tmp_path):
+    """PUT on a non-existent server_id returns 404."""
+    from api.main import app
+
+    config_path = tmp_path / ".cursor" / "mcp.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps({"mcpServers": {}}), encoding="utf-8")
+
+    client = TestClient(app)
+    headers = {"Authorization": "Bearer api-secret"}
+
+    resp = client.put(
+        "/api/mcp/custom/ghost-server",
+        json={
+            "client": "cursor",
+            "command": "node",
+            "output_path": str(config_path),
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 404
+    assert "ghost-server" in resp.json()["detail"]
+
+
+@patch.dict("os.environ", {"STRATIFYAI_API_KEY": "api-secret"})
+def test_update_custom_mcp_server_updates_settings(tmp_path):
+    """PUT with enabled/auto_start writes to permission metadata."""
+    import api.main as api_main
+    from api.main import app
+
+    config_path = tmp_path / ".cursor" / "mcp.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps({"mcpServers": {"my-server": {"command": "node"}}}),
+        encoding="utf-8",
+    )
+
+    original_engine = api_main._mcp_chat_engine
+    api_main._mcp_chat_engine = None
+    try:
+        client = TestClient(app)
+        headers = {"Authorization": "Bearer api-secret"}
+
+        resp = client.put(
+            "/api/mcp/custom/my-server",
+            json={
+                "client": "cursor",
+                "enabled": False,
+                "auto_start": False,
+                "output_path": str(config_path),
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 200
+
+        written = json.loads(config_path.read_text(encoding="utf-8"))
+        settings = written.get("stratifyai", {}).get("mcpClient", {}).get("servers", {})
+        assert settings["my-server"]["enabled"] is False
+        assert settings["my-server"]["auto_start"] is False
+    finally:
+        api_main._mcp_chat_engine = original_engine
+
+
+@patch.dict("os.environ", {"STRATIFYAI_API_KEY": "api-secret"})
+def test_delete_custom_mcp_server_removes_from_config(tmp_path):
+    """DELETE removes the server from the config file."""
+    import api.main as api_main
+    from api.main import app
+
+    config_path = tmp_path / ".cursor" / "mcp.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "my-server": {"command": "node"},
+                    "other-server": {"command": "python"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    original_engine = api_main._mcp_chat_engine
+    api_main._mcp_chat_engine = None
+    try:
+        client = TestClient(app)
+        headers = {"Authorization": "Bearer api-secret"}
+
+        resp = client.delete(
+            f"/api/mcp/custom/my-server?client=cursor&output_path={config_path}",
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["server_id"] == "my-server"
+        assert body["removed"] is True
+
+        # Verify on disk: only other-server remains.
+        written = json.loads(config_path.read_text(encoding="utf-8"))
+        assert "my-server" not in written["mcpServers"]
+        assert "other-server" in written["mcpServers"]
+    finally:
+        api_main._mcp_chat_engine = original_engine
+
+
+@patch.dict("os.environ", {"STRATIFYAI_API_KEY": "api-secret"})
+def test_delete_custom_mcp_server_not_found_returns_404(tmp_path):
+    """DELETE on a non-existent server_id returns 404."""
+    from api.main import app
+
+    config_path = tmp_path / ".cursor" / "mcp.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps({"mcpServers": {}}), encoding="utf-8")
+
+    client = TestClient(app)
+    headers = {"Authorization": "Bearer api-secret"}
+
+    resp = client.delete(
+        f"/api/mcp/custom/ghost-server?client=cursor&output_path={config_path}",
+        headers=headers,
+    )
+    assert resp.status_code == 404
+    assert "ghost-server" in resp.json()["detail"]
+
+
+@patch.dict("os.environ", {"STRATIFYAI_API_KEY": "api-secret"})
+def test_update_custom_mcp_server_claude_code_rejected():
+    """PUT with claude-code client returns 400 (not supported)."""
+    from api.main import app
+
+    client = TestClient(app)
+    headers = {"Authorization": "Bearer api-secret"}
+
+    resp = client.put(
+        "/api/mcp/custom/my-server",
+        json={"client": "claude-code", "command": "node"},
+        headers=headers,
+    )
+    assert resp.status_code == 400
+
+
+@patch.dict("os.environ", {"STRATIFYAI_API_KEY": "api-secret"})
+def test_delete_custom_mcp_server_claude_code_rejected():
+    """DELETE with claude-code client returns 400 (not supported)."""
+    from api.main import app
+
+    client = TestClient(app)
+    headers = {"Authorization": "Bearer api-secret"}
+
+    resp = client.delete(
+        "/api/mcp/custom/my-server?client=claude-code",
+        headers=headers,
+    )
+    assert resp.status_code == 400


### PR DESCRIPTION
feat(mcp):edit and delete custom servers

Closes #67

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Phase 4 of the custom MCP server flow: a `PUT /api/mcp/custom/{server_id}` edit endpoint and a `DELETE /api/mcp/custom/{server_id}` delete endpoint, along with the corresponding frontend edit form, delete button, TypeScript types, and test coverage. The fix commit addressed the previously noted args/env clearing bug (now sends `[]`/`{}` instead of `undefined`) and removed the dead `MCPCustomServerDeleteRequest` class. The backend implementation, validation, and test suite are solid.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0/P1 issues; all remaining findings are P2 style/UX improvements.

The backend endpoints are correctly implemented with proper validation, auth, and error handling. The fix commit resolved the prior args/env clearing bugs. The two remaining issues (silent command no-op and identical Delete/Remove button styling) are P2 concerns that don't block merge or corrupt data.

frontend/src/lib/components/mcp/MCPServersPage.svelte — minor UX issues around the command field and duplicate danger buttons.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/main.py | Adds PUT and DELETE endpoints for custom MCP servers with proper validation (MCPCustomServerUpdateRequest model with field validators), claude-code guard, 404 handling, and permission metadata updates. |
| frontend/src/lib/api/client.ts | Adds updateCustomMcp and deleteCustomMcp API functions with correct URL encoding via encodeURIComponent and appropriate query param handling for delete. |
| frontend/src/lib/api/types.ts | Adds McpCustomServerUpdateRequest and McpCustomServerDeleteResponse TypeScript interfaces that correctly mirror the backend Pydantic models. |
| frontend/src/lib/components/mcp/MCPServersPage.svelte | Adds edit form and delete flow for custom servers; args/env clearing is now correctly handled (fix commit), but command silently no-ops when blank, and new Delete + existing Remove buttons have identical visual styling with different semantics. |
| tests/test_api_endpoints.py | Good test coverage for Phase 4: merge-only update, 404 for missing server, settings update, delete success, delete 404, and claude-code rejection for both endpoints. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: frontend/src/lib/components/mcp/MCPServersPage.svelte
Line: 255

Comment:
**Blanking the command field silently no-ops**

`editCommand || undefined` serializes to `undefined` (omitted in JSON) when the command is cleared, so `payload.command` arrives as `None` on the backend and the merge skips it. The save returns 200 and shows "Server updated", but the command is unchanged — no feedback to the user.

The backend validator (`validate_command`) already rejects empty strings, so sending the raw empty string would produce a proper 422 error. A simpler fix is a pre-flight guard in `submitEdit`:

```suggestion
      command: editCommand.trim() ? editCommand : undefined,
```

Or add an explicit guard before the API call:
```typescript
if (!editCommand.trim()) {
  error = 'Command is required.';
  return;
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: frontend/src/lib/components/mcp/MCPServersPage.svelte
Line: 920-938

Comment:
**Two visually identical danger buttons with different semantics**

Custom servers now show both a "Delete" button (new, calls `DELETE /api/mcp/custom/{serverId}` — removes entry from the config file) and a "Remove" button (pre-existing, calls `mcpRuntimeActions.removeServer` — removes from the runtime engine). Both use the `<Trash2>` icon and `variant="danger"`, so they look identical.

A user who just wants to get rid of a custom server will face two identically styled destructive buttons with no inline hint about the difference. Consider differentiating them visually (e.g., a different icon such as `FileMinus` for the config-level delete, or a tooltip explaining the scope of each action).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(MCP): address issues found on PR 72 ..."](https://github.com/bytes0211/stratifyai/commit/24dfbc7edbf63b3c4368c8747bb0337c3d9a7843) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28083814)</sub>

<!-- /greptile_comment -->