### PR TITLE
PR - Custom MCP Phase 5: Import and Export

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -3325,6 +3325,227 @@ async def delete_custom_mcp_server(
         raise HTTPException(status_code=400, detail=sanitize_error(str(exc))) from exc
 
 
+class MCPCustomExportEntry(BaseModel):
+    """A single custom server entry for import/export."""
+
+    server_id: str
+    command: str
+    args: list[str] = Field(default_factory=list)
+    env: dict[str, str] = Field(default_factory=dict)
+
+
+class MCPCustomImportRequest(BaseModel):
+    """Request model for bulk importing custom MCP servers."""
+
+    client: str
+    servers: list[MCPCustomExportEntry]
+    overwrite: bool = False
+    project_root: str | None = None
+    output_path: str | None = None
+
+    @field_validator("client")
+    @classmethod
+    def validate_client(cls, value: str) -> str:
+        """Validate the target client identifier."""
+        allowed = {"claude-desktop", "claude-code", "cursor", "vscode"}
+        if value not in allowed:
+            raise ValueError(f"client must be one of: {', '.join(sorted(allowed))}")
+        return value
+
+
+class MCPCustomImportResponse(BaseModel):
+    """Response model for bulk import results."""
+
+    added: int = 0
+    skipped: int = 0
+    errors: int = 0
+    details: list[dict[str, str]] = Field(default_factory=list)
+    path: str | None = None
+
+
+@app.get("/api/mcp/custom/export")
+async def export_custom_mcp_servers(
+    client: str,
+    project_root: str | None = None,
+    output_path: str | None = None,
+    _: None = Depends(verify_api_key),
+):
+    """Export all non-catalog (custom) MCP servers as a JSON array."""
+    allowed_clients = {"claude-desktop", "claude-code", "cursor", "vscode"}
+    if client not in allowed_clients:
+        raise HTTPException(
+            status_code=400,
+            detail=f"client must be one of: {', '.join(sorted(allowed_clients))}",
+        )
+
+    if client == "claude-code":
+        raise HTTPException(
+            status_code=400,
+            detail="Claude Code does not use a local config file. Export is not supported.",
+        )
+
+    _, configured = get_configured_servers(
+        client=client,
+        project_root=project_root,
+        output_path=output_path,
+    )
+
+    catalog = load_mcp_server_catalog()
+    catalog_ids = {s.id for s in catalog.servers}
+
+    custom_servers: list[dict[str, Any]] = []
+    for server_id, config in sorted(configured.items()):
+        if server_id in catalog_ids:
+            continue
+        if not isinstance(config, dict):
+            continue
+        custom_servers.append(
+            {
+                "server_id": server_id,
+                "command": config.get("command", ""),
+                "args": config.get("args", []),
+                "env": config.get("env", {}),
+            }
+        )
+
+    return {"client": client, "servers": custom_servers, "count": len(custom_servers)}
+
+
+@app.post("/api/mcp/custom/import", response_model=MCPCustomImportResponse)
+async def import_custom_mcp_servers(
+    payload: MCPCustomImportRequest,
+    _: None = Depends(verify_api_key),
+):
+    """Bulk import custom MCP server definitions into a client config."""
+    if payload.client == "claude-code":
+        raise HTTPException(
+            status_code=400,
+            detail="Claude Code does not use a local config file. Import is not supported.",
+        )
+
+    _, existing_servers = get_configured_servers(
+        client=payload.client,
+        project_root=payload.project_root,
+        output_path=payload.output_path,
+    )
+
+    added = 0
+    skipped = 0
+    errors = 0
+    details: list[dict[str, str]] = []
+    path: Path | None = None
+
+    for entry in payload.servers:
+        sid = entry.server_id.strip()
+        if not sid:
+            errors += 1
+            details.append(
+                {"server_id": sid, "status": "error", "reason": "empty server_id"}
+            )
+            continue
+
+        if "/" in sid or "\\" in sid:
+            errors += 1
+            details.append(
+                {
+                    "server_id": sid,
+                    "status": "error",
+                    "reason": "server_id contains path separators",
+                }
+            )
+            continue
+
+        cmd = entry.command.strip()
+        if not cmd:
+            errors += 1
+            details.append(
+                {"server_id": sid, "status": "error", "reason": "empty command"}
+            )
+            continue
+
+        if _SHELL_METACHAR_RE.search(cmd):
+            errors += 1
+            details.append(
+                {
+                    "server_id": sid,
+                    "status": "error",
+                    "reason": "command contains shell metacharacters",
+                }
+            )
+            continue
+
+        if sid in existing_servers and not payload.overwrite:
+            skipped += 1
+            details.append(
+                {"server_id": sid, "status": "skipped", "reason": "already exists"}
+            )
+            continue
+
+        server_config: dict[str, Any] = {"command": cmd}
+        if entry.args:
+            server_config["args"] = entry.args
+        if entry.env:
+            server_config["env"] = entry.env
+
+        config: dict[str, Any]
+        if payload.client == "vscode":
+            config = {"mcp": {"servers": {sid: server_config}}}
+        else:
+            config = {"mcpServers": {sid: server_config}}
+
+        try:
+            path = write_client_config(
+                client=payload.client,
+                config=config,
+                project_root=payload.project_root,
+                output_path=payload.output_path,
+            )
+            write_mcp_client_settings(
+                client=payload.client,
+                settings={
+                    "servers": {
+                        sid: {
+                            "enabled": True,
+                            "auto_start": True,
+                            "permissions": {
+                                "default_mode": "confirm",
+                                "allow": [],
+                                "deny": [],
+                                "confirm": [],
+                            },
+                        }
+                    }
+                },
+                project_root=payload.project_root,
+                output_path=payload.output_path,
+            )
+            existing_servers[sid] = server_config
+            added += 1
+            details.append({"server_id": sid, "status": "added"})
+        except Exception as exc:
+            errors += 1
+            details.append(
+                {
+                    "server_id": sid,
+                    "status": "error",
+                    "reason": sanitize_error(str(exc)),
+                }
+            )
+
+    if added > 0:
+        global _mcp_chat_engine
+        if _mcp_chat_engine is not None:
+            await get_mcp_chat_engine(refresh=True)
+
+    return MCPCustomImportResponse(
+        added=added,
+        skipped=skipped,
+        errors=errors,
+        details=details,
+        path=str(path) if path is not None else None,
+    )
+
+
 @app.post("/api/mcp/reset", response_model=MCPResetResponse)
 async def reset_mcp_config(
     payload: MCPResetRequest,

--- a/api/main.py
+++ b/api/main.py
@@ -3493,6 +3493,8 @@ async def import_custom_mcp_servers(
         else:
             config = {"mcpServers": {sid: server_config}}
 
+        # Each server is written individually; if a later write fails the
+        # earlier ones remain (intentional partial-success — no rollback).
         try:
             path = write_client_config(
                 client=payload.client,

--- a/cli/stratifyai_cli.py
+++ b/cli/stratifyai_cli.py
@@ -672,6 +672,225 @@ def mcp_add_custom(
         raise typer.Exit(1) from exc
 
 
+@mcp_app.command("export-custom")
+def mcp_export_custom(
+    client: str | None = typer.Option(
+        None,
+        "--client",
+        help="Target client: claude-desktop, claude-code, cursor, vscode",
+    ),
+    project_root: Path | None = typer.Option(
+        None, "--project-root", help="Project root for Cursor/VS Code config lookup"
+    ),
+    output_path: Path | None = typer.Option(
+        None, "--output", help="Override config path to inspect"
+    ),
+    output_file: Path | None = typer.Option(
+        None, "--file", "-f", help="Write JSON to this file instead of stdout"
+    ),
+) -> None:
+    """Export non-catalog (custom) MCP servers as JSON."""
+    try:
+        selected_client = _resolve_mcp_client(client)
+
+        if selected_client == "claude-code":
+            console.print(
+                "[yellow]Claude Code does not use a local config file. "
+                "Export is not supported.[/yellow]"
+            )
+            raise typer.Exit(1)
+
+        path, servers = get_configured_servers(
+            client=selected_client,
+            project_root=project_root,
+            output_path=output_path,
+        )
+
+        catalog_ids: set[str] = set()
+        try:
+            for srv in list_mcp_servers():
+                catalog_ids.add(srv.id)
+        except Exception:
+            pass
+
+        custom_entries: list[dict[str, Any]] = []
+        for server_id, config in sorted(servers.items()):
+            if server_id in catalog_ids:
+                continue
+            if not isinstance(config, dict):
+                continue
+            custom_entries.append(
+                {
+                    "server_id": server_id,
+                    "command": config.get("command", ""),
+                    "args": config.get("args", []),
+                    "env": config.get("env", {}),
+                }
+            )
+
+        output_text = json.dumps(custom_entries, indent=2)
+
+        if output_file:
+            output_file.parent.mkdir(parents=True, exist_ok=True)
+            output_file.write_text(output_text + "\n", encoding="utf-8")
+            console.print(
+                f"[green]✓ Exported {len(custom_entries)} custom server(s) to[/green] {output_file}"
+            )
+        else:
+            typer.echo(output_text)
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        console.print(f"[red]Export failed:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+
+@mcp_app.command("import-custom")
+def mcp_import_custom(
+    client: str | None = typer.Option(
+        None,
+        "--client",
+        help="Target client: claude-desktop, claude-code, cursor, vscode",
+    ),
+    input_file: Path | None = typer.Option(
+        None, "--file", "-f", help="Read JSON from this file instead of stdin"
+    ),
+    project_root: Path | None = typer.Option(
+        None, "--project-root", help="Project root for Cursor/VS Code config generation"
+    ),
+    output_path: Path | None = typer.Option(
+        None, "--output", help="Override output config path"
+    ),
+    overwrite: bool = typer.Option(
+        False, "--overwrite", help="Overwrite existing servers with the same id"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Preview what would be imported without writing"
+    ),
+) -> None:
+    """Import custom MCP servers from a JSON file or stdin."""
+    import re as _re
+
+    _shell_metachar_re = _re.compile(r"[;|&`]|\$\(")
+
+    try:
+        selected_client = _resolve_mcp_client(client)
+
+        if selected_client == "claude-code":
+            console.print(
+                "[yellow]Claude Code does not use a local config file. "
+                "Import is not supported.[/yellow]"
+            )
+            raise typer.Exit(1)
+
+        if input_file:
+            raw_text = input_file.read_text(encoding="utf-8")
+        else:
+            raw_text = sys.stdin.read()
+
+        entries = json.loads(raw_text)
+        if not isinstance(entries, list):
+            console.print("[red]Import file must contain a JSON array.[/red]")
+            raise typer.Exit(1)
+
+        _, existing_servers = get_configured_servers(
+            client=selected_client,
+            project_root=project_root,
+            output_path=output_path,
+        )
+
+        added = 0
+        skipped = 0
+        errors = 0
+
+        for entry in entries:
+            sid = str(entry.get("server_id", "")).strip()
+            cmd = str(entry.get("command", "")).strip()
+
+            if not sid:
+                console.print("[red]✗ Skipping entry with empty server_id[/red]")
+                errors += 1
+                continue
+
+            if not cmd:
+                console.print(f"[red]✗ {sid}: empty command[/red]")
+                errors += 1
+                continue
+
+            if _shell_metachar_re.search(cmd):
+                console.print(
+                    f"[red]✗ {sid}: command contains shell metacharacters[/red]"
+                )
+                errors += 1
+                continue
+
+            if sid in existing_servers and not overwrite:
+                console.print(
+                    f"[yellow]⊘ {sid}: already exists (use --overwrite)[/yellow]"
+                )
+                skipped += 1
+                continue
+
+            server_config: dict[str, Any] = {"command": cmd}
+            args = entry.get("args", [])
+            env = entry.get("env", {})
+            if args:
+                server_config["args"] = list(args)
+            if env:
+                server_config["env"] = dict(env)
+
+            if dry_run:
+                console.print(f"[dim]+ {sid}: {cmd}[/dim]")
+                added += 1
+                continue
+
+            if selected_client == "vscode":
+                config = {"mcp": {"servers": {sid: server_config}}}
+            else:
+                config = {"mcpServers": {sid: server_config}}
+
+            write_client_config(
+                client=selected_client,
+                config=config,
+                project_root=project_root,
+                output_path=output_path,
+            )
+            write_mcp_client_settings(
+                client=selected_client,
+                settings={
+                    "servers": {
+                        sid: {
+                            "enabled": True,
+                            "auto_start": True,
+                            "permissions": {
+                                "default_mode": "confirm",
+                                "allow": [],
+                                "deny": [],
+                                "confirm": [],
+                            },
+                        }
+                    }
+                },
+                project_root=project_root,
+                output_path=output_path,
+            )
+            existing_servers[sid] = server_config
+            console.print(f"[green]✓ {sid}[/green]")
+            added += 1
+
+        prefix = "[dim]Dry run:[/dim] " if dry_run else ""
+        console.print(
+            f"\n{prefix}[green]{added} added[/green], "
+            f"[yellow]{skipped} skipped[/yellow], "
+            f"[red]{errors} errors[/red]"
+        )
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        console.print(f"[red]Import failed:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+
 @mcp_app.command("remove")
 def mcp_remove(
     server_id: str = typer.Argument(..., help="Configured server id to remove"),

--- a/cli/stratifyai_cli.py
+++ b/cli/stratifyai_cli.py
@@ -812,6 +812,11 @@ def mcp_import_custom(
                 errors += 1
                 continue
 
+            if "/" in sid or "\\" in sid:
+                console.print(f"[red]✗ {sid}: server_id contains path separators[/red]")
+                errors += 1
+                continue
+
             if not cmd:
                 console.print(f"[red]✗ {sid}: empty command[/red]")
                 errors += 1

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -18,6 +18,9 @@ import type {
   McpCustomServerUpdateRequest,
   McpCustomServerUpdateResponse,
   McpCustomServerDeleteResponse,
+  McpCustomExportResponse,
+  McpCustomImportRequest,
+  McpCustomImportResponse,
   McpResetRequest,
   McpResetResponse,
   McpToolsResponse,
@@ -170,6 +173,30 @@ export async function deleteCustomMcp(
     `/mcp/custom/${encodeURIComponent(serverId)}?${params.toString()}`,
     { method: 'DELETE' }
   );
+}
+
+export async function exportCustomMcp(
+  client: McpConfigureRequest['client'],
+  projectRoot?: string,
+  outputPath?: string
+): Promise<McpCustomExportResponse> {
+  const params = new URLSearchParams({ client });
+  if (projectRoot) {
+    params.set('project_root', projectRoot);
+  }
+  if (outputPath) {
+    params.set('output_path', outputPath);
+  }
+  return request<McpCustomExportResponse>(`/mcp/custom/export?${params.toString()}`);
+}
+
+export async function importCustomMcp(
+  req: McpCustomImportRequest
+): Promise<McpCustomImportResponse> {
+  return request<McpCustomImportResponse>('/mcp/custom/import', {
+    method: 'POST',
+    body: JSON.stringify(req),
+  });
 }
 
 export async function resetMcpConfig(req: McpResetRequest): Promise<McpResetResponse> {

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -309,6 +309,35 @@ export interface McpCustomServerDeleteResponse {
   path: string;
 }
 
+export interface McpCustomExportEntry {
+  server_id: string;
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+}
+
+export interface McpCustomExportResponse {
+  client: string;
+  servers: McpCustomExportEntry[];
+  count: number;
+}
+
+export interface McpCustomImportRequest {
+  client: 'claude-desktop' | 'claude-code' | 'cursor' | 'vscode';
+  servers: McpCustomExportEntry[];
+  overwrite?: boolean;
+  project_root?: string;
+  output_path?: string;
+}
+
+export interface McpCustomImportResponse {
+  added: number;
+  skipped: number;
+  errors: number;
+  details: Array<{ server_id: string; status: string; reason?: string }>;
+  path?: string | null;
+}
+
 export interface McpResetRequest {
   client: 'claude-desktop' | 'claude-code' | 'cursor' | 'vscode';
   server_ids?: string[];

--- a/frontend/src/lib/components/mcp/MCPServersPage.svelte
+++ b/frontend/src/lib/components/mcp/MCPServersPage.svelte
@@ -292,7 +292,7 @@
       link.href = url;
       link.download = `${selectedClient}-custom-servers.json`;
       link.click();
-      URL.revokeObjectURL(url);
+      setTimeout(() => URL.revokeObjectURL(url), 100);
       statusMessage = `Exported ${result.count} custom server(s).`;
     } catch (err) {
       error = err instanceof Error ? err.message : 'Failed to export custom servers';

--- a/frontend/src/lib/components/mcp/MCPServersPage.svelte
+++ b/frontend/src/lib/components/mcp/MCPServersPage.svelte
@@ -3,10 +3,12 @@
   import {
     configureMcp,
     deleteCustomMcp,
+    exportCustomMcp,
     getMcpCatalog,
     getMcpClientPermissions,
     getMcpClients,
     getMcpStatus,
+    importCustomMcp,
     resetMcpConfig,
     updateCustomMcp,
     updateMcpClientPermissions,
@@ -41,6 +43,7 @@
     Shield,
     Square,
     Trash2,
+    Upload,
     Wrench,
     X,
   } from 'lucide-svelte';
@@ -81,6 +84,9 @@
   let editCommand = '';
   let editArgs: string[] = [];
   let editEnvPairs: Array<{ key: string; value: string }> = [];
+
+  // --- Phase 5: Import file input reference ---
+  let importFileInput: HTMLInputElement;
 
   onMount(() => {
     void initialize();
@@ -264,6 +270,72 @@
       error = err instanceof Error ? err.message : `Failed to update ${editingServerId}`;
     } finally {
       runtimeActionLoading = '';
+    }
+  }
+
+  // --- Phase 5: Export / Import handlers ---
+
+  async function exportServers() {
+    try {
+      actionLoading = true;
+      error = null;
+      const result = await exportCustomMcp(selectedClient, projectRoot || undefined);
+      if (result.count === 0) {
+        statusMessage = 'No custom (non-catalog) servers to export.';
+        return;
+      }
+      const blob = new Blob([JSON.stringify(result.servers, null, 2)], {
+        type: 'application/json;charset=utf-8',
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `${selectedClient}-custom-servers.json`;
+      link.click();
+      URL.revokeObjectURL(url);
+      statusMessage = `Exported ${result.count} custom server(s).`;
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Failed to export custom servers';
+    } finally {
+      actionLoading = false;
+    }
+  }
+
+  function triggerImportFile() {
+    importFileInput?.click();
+  }
+
+  async function handleImportFile(event: Event) {
+    const input = event.currentTarget as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+
+    try {
+      actionLoading = true;
+      error = null;
+      const text = await file.text();
+      const servers = JSON.parse(text);
+      if (!Array.isArray(servers)) {
+        error = 'Import file must contain a JSON array of server entries.';
+        return;
+      }
+      const result = await importCustomMcp({
+        client: selectedClient,
+        servers,
+        overwrite: false,
+        project_root: projectRoot || undefined,
+      });
+      const parts: string[] = [];
+      if (result.added > 0) parts.push(`${result.added} added`);
+      if (result.skipped > 0) parts.push(`${result.skipped} skipped`);
+      if (result.errors > 0) parts.push(`${result.errors} errors`);
+      statusMessage = `Import complete: ${parts.join(', ')}.`;
+      await refreshStatus();
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Failed to import custom servers';
+    } finally {
+      actionLoading = false;
+      input.value = '';
     }
   }
 
@@ -769,6 +841,34 @@
             <Download size={14} />
             Download
           </Button>
+        </div>
+
+        <div class="action-row secondary-actions">
+          <Button
+            variant="ghost"
+            size="sm"
+            on:click={exportServers}
+            disabled={actionLoading || !selectedClientInfo?.supports_apply}
+          >
+            <Download size={14} />
+            Export custom
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            on:click={triggerImportFile}
+            disabled={actionLoading || !selectedClientInfo?.supports_apply}
+          >
+            <Upload size={14} />
+            Import custom
+          </Button>
+          <input
+            bind:this={importFileInput}
+            type="file"
+            accept=".json"
+            style="display:none"
+            on:change={handleImportFile}
+          />
         </div>
 
         {#if statusMessage}

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1270,3 +1270,364 @@ def test_delete_custom_mcp_server_claude_code_rejected():
         headers=headers,
     )
     assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 — Import and Export Custom Servers
+# ---------------------------------------------------------------------------
+
+
+@patch.dict("os.environ", {"STRATIFYAI_API_KEY": "api-secret"})
+def test_export_custom_returns_only_non_catalog_servers(tmp_path):
+    """Export returns custom (non-catalog) servers only."""
+    from api.main import app
+
+    config_path = tmp_path / ".cursor" / "mcp.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "stratifyai": {"command": "npx", "args": ["stratifyai-mcp"]},
+                    "my-custom-tool": {
+                        "command": "python",
+                        "args": ["-m", "my_tool"],
+                        "env": {"KEY": "val"},
+                    },
+                    "another-custom": {"command": "node", "args": ["server.js"]},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    client = TestClient(app)
+    headers = {"Authorization": "Bearer api-secret"}
+
+    resp = client.get(
+        f"/api/mcp/custom/export?client=cursor&output_path={config_path}",
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    exported_ids = [s["server_id"] for s in body["servers"]]
+    # "stratifyai" is a catalog server; the two custom ones should be exported.
+    assert "stratifyai" not in exported_ids
+    assert "my-custom-tool" in exported_ids
+    assert "another-custom" in exported_ids
+    assert body["count"] == 2
+    # Verify full structure of exported entries.
+    custom_tool = next(s for s in body["servers"] if s["server_id"] == "my-custom-tool")
+    assert custom_tool["command"] == "python"
+    assert custom_tool["args"] == ["-m", "my_tool"]
+    assert custom_tool["env"] == {"KEY": "val"}
+
+
+@patch.dict("os.environ", {"STRATIFYAI_API_KEY": "api-secret"})
+def test_export_custom_empty_when_all_catalog(tmp_path):
+    """Export returns empty array when only catalog servers are configured."""
+    from api.main import app
+
+    config_path = tmp_path / ".cursor" / "mcp.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps({"mcpServers": {"stratifyai": {"command": "npx"}}}),
+        encoding="utf-8",
+    )
+
+    client = TestClient(app)
+    headers = {"Authorization": "Bearer api-secret"}
+
+    resp = client.get(
+        f"/api/mcp/custom/export?client=cursor&output_path={config_path}",
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 0
+    assert resp.json()["servers"] == []
+
+
+@patch.dict("os.environ", {"STRATIFYAI_API_KEY": "api-secret"})
+def test_export_custom_claude_code_rejected():
+    """Export with claude-code client returns 400."""
+    from api.main import app
+
+    client = TestClient(app)
+    headers = {"Authorization": "Bearer api-secret"}
+
+    resp = client.get(
+        "/api/mcp/custom/export?client=claude-code",
+        headers=headers,
+    )
+    assert resp.status_code == 400
+
+
+@patch.dict("os.environ", {"STRATIFYAI_API_KEY": "api-secret"})
+def test_import_custom_validates_and_writes_correctly(tmp_path):
+    """Import validates each entry and writes to the config file."""
+    import api.main as api_main
+    from api.main import app
+
+    config_path = tmp_path / ".cursor" / "mcp.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps({"mcpServers": {}}), encoding="utf-8")
+
+    original_engine = api_main._mcp_chat_engine
+    api_main._mcp_chat_engine = None
+    try:
+        client = TestClient(app)
+        headers = {"Authorization": "Bearer api-secret"}
+
+        resp = client.post(
+            "/api/mcp/custom/import",
+            json={
+                "client": "cursor",
+                "output_path": str(config_path),
+                "servers": [
+                    {
+                        "server_id": "tool-a",
+                        "command": "python",
+                        "args": ["-m", "a"],
+                        "env": {"K": "v"},
+                    },
+                    {
+                        "server_id": "tool-b",
+                        "command": "node",
+                        "args": ["b.js"],
+                        "env": {},
+                    },
+                ],
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["added"] == 2
+        assert body["skipped"] == 0
+        assert body["errors"] == 0
+
+        written = json.loads(config_path.read_text(encoding="utf-8"))
+        assert "tool-a" in written["mcpServers"]
+        assert written["mcpServers"]["tool-a"]["command"] == "python"
+        assert "tool-b" in written["mcpServers"]
+        assert written["mcpServers"]["tool-b"]["command"] == "node"
+    finally:
+        api_main._mcp_chat_engine = original_engine
+
+
+@patch.dict("os.environ", {"STRATIFYAI_API_KEY": "api-secret"})
+def test_import_custom_handles_duplicates_gracefully(tmp_path):
+    """Import skips duplicate server_ids when overwrite is not set."""
+    import api.main as api_main
+    from api.main import app
+
+    config_path = tmp_path / ".cursor" / "mcp.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps({"mcpServers": {"existing": {"command": "node"}}}),
+        encoding="utf-8",
+    )
+
+    original_engine = api_main._mcp_chat_engine
+    api_main._mcp_chat_engine = None
+    try:
+        client = TestClient(app)
+        headers = {"Authorization": "Bearer api-secret"}
+
+        resp = client.post(
+            "/api/mcp/custom/import",
+            json={
+                "client": "cursor",
+                "output_path": str(config_path),
+                "servers": [
+                    {"server_id": "existing", "command": "python"},
+                    {"server_id": "new-tool", "command": "deno"},
+                ],
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["added"] == 1
+        assert body["skipped"] == 1
+        assert body["errors"] == 0
+
+        # "existing" should keep original config; "new-tool" should be written.
+        written = json.loads(config_path.read_text(encoding="utf-8"))
+        assert written["mcpServers"]["existing"]["command"] == "node"
+        assert written["mcpServers"]["new-tool"]["command"] == "deno"
+    finally:
+        api_main._mcp_chat_engine = original_engine
+
+
+@patch.dict("os.environ", {"STRATIFYAI_API_KEY": "api-secret"})
+def test_import_custom_with_overwrite_replaces_existing(tmp_path):
+    """Import with overwrite=true replaces existing servers."""
+    import api.main as api_main
+    from api.main import app
+
+    config_path = tmp_path / ".cursor" / "mcp.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps({"mcpServers": {"existing": {"command": "node"}}}),
+        encoding="utf-8",
+    )
+
+    original_engine = api_main._mcp_chat_engine
+    api_main._mcp_chat_engine = None
+    try:
+        client = TestClient(app)
+        headers = {"Authorization": "Bearer api-secret"}
+
+        resp = client.post(
+            "/api/mcp/custom/import",
+            json={
+                "client": "cursor",
+                "output_path": str(config_path),
+                "overwrite": True,
+                "servers": [
+                    {"server_id": "existing", "command": "python"},
+                ],
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["added"] == 1
+        assert body["skipped"] == 0
+
+        written = json.loads(config_path.read_text(encoding="utf-8"))
+        assert written["mcpServers"]["existing"]["command"] == "python"
+    finally:
+        api_main._mcp_chat_engine = original_engine
+
+
+@patch.dict("os.environ", {"STRATIFYAI_API_KEY": "api-secret"})
+def test_import_custom_rejects_bad_entries(tmp_path):
+    """Import reports errors for invalid entries (empty cmd, metacharacters)."""
+    import api.main as api_main
+    from api.main import app
+
+    config_path = tmp_path / ".cursor" / "mcp.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps({"mcpServers": {}}), encoding="utf-8")
+
+    original_engine = api_main._mcp_chat_engine
+    api_main._mcp_chat_engine = None
+    try:
+        client = TestClient(app)
+        headers = {"Authorization": "Bearer api-secret"}
+
+        resp = client.post(
+            "/api/mcp/custom/import",
+            json={
+                "client": "cursor",
+                "output_path": str(config_path),
+                "servers": [
+                    {"server_id": "", "command": "python"},
+                    {"server_id": "evil", "command": "node; rm -rf /"},
+                    {"server_id": "no-cmd", "command": ""},
+                    {"server_id": "good", "command": "deno"},
+                ],
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["added"] == 1
+        assert body["errors"] == 3
+
+        # Only "good" should be written.
+        written = json.loads(config_path.read_text(encoding="utf-8"))
+        assert "good" in written["mcpServers"]
+        assert "evil" not in written["mcpServers"]
+    finally:
+        api_main._mcp_chat_engine = original_engine
+
+
+@patch.dict("os.environ", {"STRATIFYAI_API_KEY": "api-secret"})
+def test_import_custom_claude_code_rejected():
+    """Import with claude-code client returns 400."""
+    from api.main import app
+
+    client = TestClient(app)
+    headers = {"Authorization": "Bearer api-secret"}
+
+    resp = client.post(
+        "/api/mcp/custom/import",
+        json={
+            "client": "claude-code",
+            "servers": [{"server_id": "a", "command": "b"}],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 400
+
+
+@patch.dict("os.environ", {"STRATIFYAI_API_KEY": "api-secret"})
+def test_export_then_import_round_trip(tmp_path):
+    """Export followed by import into a fresh config preserves all fields."""
+    import api.main as api_main
+    from api.main import app
+
+    # Set up source config with custom servers.
+    src_path = tmp_path / "src" / ".cursor" / "mcp.json"
+    src_path.parent.mkdir(parents=True, exist_ok=True)
+    src_path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "custom-a": {
+                        "command": "python",
+                        "args": ["-m", "a"],
+                        "env": {"X": "1"},
+                    },
+                    "custom-b": {"command": "node", "args": ["b.js"]},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # Set up destination config.
+    dst_path = tmp_path / "dst" / ".cursor" / "mcp.json"
+    dst_path.parent.mkdir(parents=True, exist_ok=True)
+    dst_path.write_text(json.dumps({"mcpServers": {}}), encoding="utf-8")
+
+    original_engine = api_main._mcp_chat_engine
+    api_main._mcp_chat_engine = None
+    try:
+        client = TestClient(app)
+        headers = {"Authorization": "Bearer api-secret"}
+
+        # Export from source.
+        export_resp = client.get(
+            f"/api/mcp/custom/export?client=cursor&output_path={src_path}",
+            headers=headers,
+        )
+        assert export_resp.status_code == 200
+        exported = export_resp.json()["servers"]
+        assert len(exported) == 2
+
+        # Import into destination.
+        import_resp = client.post(
+            "/api/mcp/custom/import",
+            json={
+                "client": "cursor",
+                "output_path": str(dst_path),
+                "servers": exported,
+            },
+            headers=headers,
+        )
+        assert import_resp.status_code == 200
+        assert import_resp.json()["added"] == 2
+
+        # Verify round-trip fidelity.
+        written = json.loads(dst_path.read_text(encoding="utf-8"))
+        assert written["mcpServers"]["custom-a"]["command"] == "python"
+        assert written["mcpServers"]["custom-a"]["args"] == ["-m", "a"]
+        assert written["mcpServers"]["custom-a"]["env"] == {"X": "1"}
+        assert written["mcpServers"]["custom-b"]["command"] == "node"
+        assert written["mcpServers"]["custom-b"]["args"] == ["b.js"]
+    finally:
+        api_main._mcp_chat_engine = original_engine


### PR DESCRIPTION
feat(mcp): import/export custom mcps

Closes #68

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements bulk import and export of custom (non-catalog) MCP server definitions across the API, CLI, and frontend. All three issues raised in the previous review round have been addressed: the CLI now validates `server_id` path separators, the API import loop carries a comment documenting intentional partial-success behaviour, and `URL.revokeObjectURL` is guarded with a `setTimeout`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all prior P1 issues are resolved and the one remaining finding is a minor dry-run edge case.

All three issues from the previous review cycle are fixed. The only new finding is a P2 inconsistency in the CLI dry-run path where duplicate server IDs in the import file would each be shown as 'added' rather than the second being shown as 'skipped'. This is an edge case unlikely to occur with real export files, which never contain duplicate keys.

cli/stratifyai_cli.py — dry-run path does not update existing_servers, giving an inaccurate preview for duplicate server IDs.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/main.py | Adds GET /api/mcp/custom/export and POST /api/mcp/custom/import endpoints with Pydantic models, client/path-separator/shell-metachar validation, per-server write loop with intentional partial-success comment, and engine refresh on success. |
| cli/stratifyai_cli.py | Adds export-custom and import-custom CLI commands; import validation mirrors the API (empty sid, path separators, empty cmd, shell metacharacters), but dry-run mode omits the existing_servers update, causing inaccurate duplicate preview for files with repeated server IDs. |
| frontend/src/lib/components/mcp/MCPServersPage.svelte | Adds exportServers / handleImportFile UI handlers; revokeObjectURL race now guarded by setTimeout(100); early-return inside try block correctly handled by finally (actionLoading reset); JSON parse errors caught. |
| frontend/src/lib/api/client.ts | Adds exportCustomMcp (GET with query params) and importCustomMcp (POST JSON) wrappers; types and parameters align with the backend models. |
| frontend/src/lib/api/types.ts | Adds McpCustomExportEntry, McpCustomExportResponse, McpCustomImportRequest, and McpCustomImportResponse interfaces; matches backend Pydantic models correctly. |
| tests/test_api_endpoints.py | Adds five Phase-5 tests covering export (non-catalog filter, all-catalog empty, claude-code rejection) and import (write, duplicate skip, overwrite, bad entries including shell metacharacters); good coverage of the API layer. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: cli/stratifyai_cli.py
Line: 847-852

Comment:
**Dry-run skips `existing_servers` update, making duplicate preview inaccurate**

When `--dry-run` is active the `continue` on line 849 fires before `existing_servers[sid] = server_config` is reached. If the import file contains two entries with the same `server_id` (neither already on disk), dry-run reports both as `added`, whereas a real run would add the first and skip the second as "already exists". The real API endpoint avoids this because it always updates `existing_servers` inside the success block.

Fix: update `existing_servers` even in dry-run mode so the duplicate check stays consistent:

```suggestion
            if dry_run:
                console.print(f"[dim]+ {sid}: {cmd}[/dim]")
                existing_servers[sid] = server_config
                added += 1
                continue
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(mcp): P2 fixes on PR 73 commit c0556..."](https://github.com/bytes0211/stratifyai/commit/f429072e68d482ada0240143a56f6ab0a1b5cdf4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28085073)</sub>

<!-- /greptile_comment -->