### PR TITLE
PR - feat(cli): MCP interactive Phase 2 — route chat through MCP engine

### DIFF
--- a/cli/stratifyai_cli.py
+++ b/cli/stratifyai_cli.py
@@ -3466,20 +3466,46 @@ def interactive(
                 )
 
             # Create request and get response
-            request = ChatRequest(
-                model=model, messages=messages, temperature=temperature
-            )
-
             try:
                 # Show spinner while waiting for response
                 with console.status("[cyan]Thinking...", spinner="dots"):
-                    response = client.chat_completion_sync(request)
+                    if use_mcp and mcp_engine is not None and active_mcp_servers:
+                        response = client.chat_with_mcp_sync(
+                            model=model,
+                            messages=messages,
+                            mcp_engine=mcp_engine,
+                            active_servers=active_mcp_servers,
+                            temperature=temperature,
+                        )
+                    else:
+                        request = ChatRequest(
+                            model=model,
+                            messages=messages,
+                            temperature=temperature,
+                        )
+                        response = client.chat_completion_sync(request)
 
                 # Add assistant message to history
                 messages.append(Message(role="assistant", content=response.content))
 
                 # Store last response for /save command
                 last_response = response
+
+                # Display MCP warnings (before tool results)
+                mcp_warnings = list(response.raw_response.get("mcp_warnings", []))
+                for _warning in mcp_warnings:
+                    console.print(f"[yellow]⚠ MCP: {_warning}[/yellow]")
+
+                # Display MCP tool results (before assistant response)
+                mcp_tool_results = list(
+                    response.raw_response.get("mcp_tool_results", [])
+                )
+                for _tr in mcp_tool_results:
+                    _server = _tr.get("server_id", "?")
+                    _tool = _tr.get("tool_name", "?")
+                    _content = str(_tr.get("content", ""))
+                    _preview = _content[:80] + "..." if len(_content) > 80 else _content
+                    console.print(f"[dim][MCP: {_server}.{_tool}] {_preview}[/dim]")
 
                 # Display metadata and response (interactive mode - cyan)
                 console.print(
@@ -3501,6 +3527,10 @@ def interactive(
                 # Add latency if available
                 if response.latency_ms is not None:
                     usage_parts.append(f"Latency: {response.latency_ms:.0f}ms")
+
+                # Add MCP tool count if tools were invoked
+                if mcp_tool_results:
+                    usage_parts.append(f"MCP tools: {len(mcp_tool_results)}")
 
                 # Add cache statistics if available
                 if response.usage.cached_tokens > 0:

--- a/cli/stratifyai_cli.py
+++ b/cli/stratifyai_cli.py
@@ -3491,21 +3491,23 @@ def interactive(
                 # Store last response for /save command
                 last_response = response
 
-                # Display MCP warnings (before tool results)
-                mcp_warnings = list(response.raw_response.get("mcp_warnings", []))
-                for _warning in mcp_warnings:
-                    console.print(f"[yellow]⚠ MCP: {_warning}[/yellow]")
+                # Display MCP warnings and tool results (only for MCP sessions)
+                mcp_tool_results: list[dict] = []
+                if use_mcp:
+                    for _warning in response.raw_response.get("mcp_warnings", []):
+                        console.print(f"[yellow]⚠ MCP: {_warning}[/yellow]")
 
-                # Display MCP tool results (before assistant response)
-                mcp_tool_results = list(
-                    response.raw_response.get("mcp_tool_results", [])
-                )
-                for _tr in mcp_tool_results:
-                    _server = _tr.get("server_id", "?")
-                    _tool = _tr.get("tool_name", "?")
-                    _content = str(_tr.get("content", ""))
-                    _preview = _content[:80] + "..." if len(_content) > 80 else _content
-                    console.print(f"[dim][MCP: {_server}.{_tool}] {_preview}[/dim]")
+                    mcp_tool_results = list(
+                        response.raw_response.get("mcp_tool_results", [])
+                    )
+                    for _tr in mcp_tool_results:
+                        _server = _tr.get("server_id", "?")
+                        _tool = _tr.get("tool_name", "?")
+                        _content = str(_tr.get("content", ""))
+                        _preview = (
+                            _content[:80] + "..." if len(_content) > 80 else _content
+                        )
+                        console.print(f"[dim][MCP: {_server}.{_tool}] {_preview}[/dim]")
 
                 # Display metadata and response (interactive mode - cyan)
                 console.print(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,9 @@
-"""Unit tests for interactive command Phase 1 MCP support (cli-mcp-interactive-plan.md)."""
+"""Unit tests for interactive command MCP support (cli-mcp-interactive-plan.md)."""
 
 from __future__ import annotations
 
 import re
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,6 +12,7 @@ from typer.testing import CliRunner
 from cli.stratifyai_cli import app
 from stratifyai.mcp_client.server_manager import ServerStatus
 from stratifyai.mcp_client.tool_registry import ToolDescriptor
+from stratifyai.models import ChatResponse, Usage
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
@@ -295,3 +297,238 @@ class TestMCPBanner:
 
         assert result.exit_code == 0, result.output
         assert "MCP:" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# Helpers for Phase 2
+# ---------------------------------------------------------------------------
+
+
+def _make_chat_response(
+    content: str = "Hello!",
+    raw_response: dict | None = None,
+) -> ChatResponse:
+    """Create a minimal ChatResponse for testing."""
+    return ChatResponse(
+        id="resp-1",
+        model="gpt-4o-mini",
+        content=content,
+        finish_reason="stop",
+        usage=Usage(
+            prompt_tokens=10,
+            completion_tokens=5,
+            total_tokens=15,
+            cost_usd=0.0001,
+        ),
+        provider="openai",
+        created_at=datetime.now(tz=timezone.utc),
+        raw_response=raw_response or {},
+        latency_ms=42.0,
+    )
+
+
+def _invoke_interactive_with_chat(
+    runner: CliRunner,
+    simple_catalog: dict,
+    mock_engine: MagicMock,
+    mock_response: ChatResponse,
+    user_message: str = "Hello",
+    use_mcp: bool = True,
+):
+    """Invoke interactive with a mock chat response, sending one message then exiting.
+
+    Args:
+        runner: Typer CliRunner.
+        simple_catalog: Mocked MODEL_CATALOG dict.
+        mock_engine: Pre-configured MCPClientEngine mock.
+        mock_response: ChatResponse to return from the chat call.
+        user_message: The message to send in the chat loop.
+        use_mcp: Whether to enable MCP.
+
+    Returns:
+        The invocation Result.
+    """
+    extra_args = ["--mcp-server", "postgresql"] if use_mcp else []
+    base_args = [
+        "interactive",
+        "--provider",
+        "openai",
+        "--model",
+        "gpt-4o-mini",
+    ]
+
+    mock_client = MagicMock()
+    mock_client.chat_with_mcp_sync.return_value = mock_response
+    mock_client.chat_completion_sync.return_value = mock_response
+
+    mock_client_class = MagicMock(return_value=mock_client)
+
+    with (
+        patch("cli.stratifyai_cli.MODEL_CATALOG", simple_catalog),
+        patch("cli.stratifyai_cli.LLMClient", mock_client_class),
+        patch(
+            "stratifyai.mcp_client.MCPClientEngine",
+            return_value=mock_engine,
+        ),
+        patch("cli.stratifyai_cli.run_sync", return_value=None),
+        patch(
+            "cli.stratifyai_cli.Prompt.ask",
+            side_effect=["", user_message, "exit"],
+        ),
+    ):
+        result = runner.invoke(app, base_args + extra_args)
+
+    return result, mock_client
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — Route chat through MCP engine
+# ---------------------------------------------------------------------------
+
+
+class TestMCPChatRouting:
+    """Phase 2: MCP-active sessions must route through chat_with_mcp_sync."""
+
+    def test_mcp_active_routes_through_chat_with_mcp_sync(
+        self, runner: CliRunner, simple_catalog: dict
+    ) -> None:
+        mock_engine = MagicMock()
+        mock_engine.list_servers.return_value = [
+            ServerStatus(server_id="postgresql", status="connected")
+        ]
+        mock_engine.list_tools.return_value = [
+            _make_tool_descriptor("postgresql", "query"),
+        ]
+
+        resp = _make_chat_response()
+        result, mock_client = _invoke_interactive_with_chat(
+            runner,
+            simple_catalog,
+            mock_engine,
+            resp,
+            use_mcp=True,
+        )
+
+        assert result.exit_code == 0, result.output
+        mock_client.chat_with_mcp_sync.assert_called_once()
+        mock_client.chat_completion_sync.assert_not_called()
+
+    def test_non_mcp_session_uses_chat_completion_sync(
+        self, runner: CliRunner, simple_catalog: dict
+    ) -> None:
+        resp = _make_chat_response()
+        mock_client = MagicMock()
+        mock_client.chat_completion_sync.return_value = resp
+
+        mock_client_class = MagicMock(return_value=mock_client)
+
+        with (
+            patch("cli.stratifyai_cli.MODEL_CATALOG", simple_catalog),
+            patch("cli.stratifyai_cli.LLMClient", mock_client_class),
+            patch(
+                "cli.stratifyai_cli.Prompt.ask",
+                side_effect=["", "Hello", "exit"],
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                ["interactive", "--provider", "openai", "--model", "gpt-4o-mini"],
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_client.chat_completion_sync.assert_called_once()
+        mock_client.chat_with_mcp_sync.assert_not_called()
+
+
+class TestMCPToolResultDisplay:
+    """Phase 2: Tool results must be displayed before the assistant response."""
+
+    def test_tool_results_displayed_in_output(
+        self, runner: CliRunner, simple_catalog: dict
+    ) -> None:
+        mock_engine = MagicMock()
+        mock_engine.list_servers.return_value = [
+            ServerStatus(server_id="postgresql", status="connected")
+        ]
+        mock_engine.list_tools.return_value = [
+            _make_tool_descriptor("postgresql", "query"),
+        ]
+
+        resp = _make_chat_response(
+            content="Here are the results.",
+            raw_response={
+                "mcp_tool_results": [
+                    {
+                        "server_id": "postgresql",
+                        "tool_name": "query",
+                        "content": "3 rows returned",
+                    },
+                ],
+            },
+        )
+        result, _ = _invoke_interactive_with_chat(
+            runner,
+            simple_catalog,
+            mock_engine,
+            resp,
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "postgresql.query" in result.output
+        assert "3 rows returned" in result.output
+
+    def test_mcp_warnings_displayed(
+        self, runner: CliRunner, simple_catalog: dict
+    ) -> None:
+        mock_engine = MagicMock()
+        mock_engine.list_servers.return_value = [
+            ServerStatus(server_id="postgresql", status="connected")
+        ]
+        mock_engine.list_tools.return_value = [
+            _make_tool_descriptor("postgresql", "query"),
+        ]
+
+        resp = _make_chat_response(
+            raw_response={
+                "mcp_warnings": ["Server postgresql is running slowly"],
+            },
+        )
+        result, _ = _invoke_interactive_with_chat(
+            runner,
+            simple_catalog,
+            mock_engine,
+            resp,
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "MCP:" in result.output
+        assert "running slowly" in result.output
+
+    def test_mcp_tool_count_in_metadata(
+        self, runner: CliRunner, simple_catalog: dict
+    ) -> None:
+        mock_engine = MagicMock()
+        mock_engine.list_servers.return_value = [
+            ServerStatus(server_id="postgresql", status="connected")
+        ]
+        mock_engine.list_tools.return_value = [
+            _make_tool_descriptor("postgresql", "query"),
+        ]
+
+        resp = _make_chat_response(
+            raw_response={
+                "mcp_tool_results": [
+                    {"server_id": "postgresql", "tool_name": "query", "content": "ok"},
+                    {"server_id": "postgresql", "tool_name": "schema", "content": "ok"},
+                ],
+            },
+        )
+        result, _ = _invoke_interactive_with_chat(
+            runner,
+            simple_catalog,
+            mock_engine,
+            resp,
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "MCP tools: 2" in result.output


### PR DESCRIPTION
feat(cli): mcp route chat to mcp

Closes #75

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Phase 2 of the MCP interactive feature: routes chat through `client.chat_with_mcp_sync` when an MCP session is active and falls back to `chat_completion_sync` otherwise. The MCP warning/tool-result display block is now correctly gated with `if use_mcp:`, addressing the concern flagged in the previous review. The only remaining feedback is a minor test-quality suggestion on the routing assertion.

<h3>Confidence Score: 5/5</h3>

Safe to merge — routing logic is correct and the only finding is a P2 test-quality suggestion.

No P0 or P1 issues found. The routing condition is well-guarded, state transitions are consistent, and the previous review concern about un-gated MCP display code has been resolved.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| cli/stratifyai_cli.py | Adds MCP chat routing: when `use_mcp and mcp_engine is not None and active_mcp_servers`, calls `client.chat_with_mcp_sync`; otherwise falls back to `chat_completion_sync`. MCP warning/tool-result display is now gated behind `if use_mcp:`, addressing the concern from the previous review thread. |
| tests/test_cli.py | New Phase 2 tests cover MCP/non-MCP routing, tool-result display, and warning display. Routing test verifies call count but not argument values, leaving argument correctness unverified. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `cli/stratifyai_cli.py`, line 3668-3671 ([link](https://github.com/bytes0211/stratifyai/blob/eb77db074645d2c0e33104ccd4e7ac59099464c8/cli/stratifyai_cli.py#L3668-L3671)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Bare `except` swallows `run_sync` errors silently in cleanup**

   The broad `except Exception: pass` in the `finally` block hides any unexpected failure during `mcp_engine.stop()`. A silent swallow is fine for cleanup, but a brief log would help when debugging. Consider at least a `console.print` or logger call at debug level so shutdown errors are observable.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: cli/stratifyai_cli.py
   Line: 3668-3671

   Comment:
   **Bare `except` swallows `run_sync` errors silently in cleanup**

   The broad `except Exception: pass` in the `finally` block hides any unexpected failure during `mcp_engine.stop()`. A silent swallow is fine for cleanup, but a brief log would help when debugging. Consider at least a `console.print` or logger call at debug level so shutdown errors are observable.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: tests/test_cli.py
Line: 412-414

Comment:
**Routing test asserts call count but not arguments**

`assert_called_once()` confirms the right method was called, but won't catch cases where the wrong `model`, `active_servers`, or `mcp_engine` is forwarded. Since the entire value of the routing logic is that the correct arguments reach the MCP engine, a stronger assertion would make this test more meaningful.

```suggestion
        mock_client.chat_with_mcp_sync.assert_called_once_with(
            model="gpt-4o-mini",
            messages=mock_client.chat_with_mcp_sync.call_args.kwargs["messages"],
            mcp_engine=mock_engine,
            active_servers=["postgresql"],
            temperature=0.7,
        )
        mock_client.chat_completion_sync.assert_not_called()
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(CLI): fixes for PR 79 on commit eb77..."](https://github.com/bytes0211/stratifyai/commit/a032037136ec1a02907e873c3bf497726737d530) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28111975)</sub>

<!-- /greptile_comment -->