### PR TITLE
PR - feat(cli): MCP interactive Phase 3 — /mcp runtime commands

### DIFF
--- a/cli/stratifyai_cli.py
+++ b/cli/stratifyai_cli.py
@@ -2957,7 +2957,7 @@ def interactive(
             )
 
         console.print(
-            "[dim]Commands: /file <path> | /attach <path> | /mcp | /clear | /save [path] | /provider | /help | exit[/dim]"
+            "[dim]Commands: /file <path> | /attach <path> | /mcp [on|off|tools|refresh] | /clear | /save | /provider | /help | exit[/dim]"
         )
         console.print(
             f"[dim]File size limit: {MAX_FILE_SIZE_MB} MB | Ctrl+C to exit[/dim]\n"
@@ -3319,40 +3319,201 @@ def interactive(
                 console.print("[dim]Conversation history preserved[/dim]\n")
                 continue
 
-            elif user_input.lower() == "/mcp":
-                # Show MCP server status
-                if not use_mcp or mcp_engine is None:
-                    console.print("[dim]MCP is not active for this session.[/dim]")
-                else:
-                    _mcp_table = Table(
-                        title="MCP Servers",
-                        show_header=True,
-                        header_style="bold cyan",
-                    )
-                    _mcp_table.add_column("Server", style="cyan")
-                    _mcp_table.add_column("Status")
-                    _mcp_table.add_column("Tools")
-                    for _status in mcp_engine.list_servers():
-                        _is_active = _status.server_id in active_mcp_servers
-                        _tool_count = tools_by_server.get(_status.server_id, 0)
-                        _indicator = "● " if _is_active else "  "
-                        if _status.status == "connected":
-                            _status_str = "[green]connected[/green]"
-                        elif _status.status in ("stopped", "disabled"):
-                            _status_str = f"[dim]{_status.status}[/dim]"
+            elif user_input.lower().startswith("/mcp"):
+                # ── /mcp subcommand dispatcher (Phase 3) ──
+                _mcp_parts = user_input.split(maxsplit=2)
+                _mcp_sub = _mcp_parts[1].lower() if len(_mcp_parts) > 1 else ""
+                _mcp_arg = _mcp_parts[2].strip() if len(_mcp_parts) > 2 else ""
+
+                if _mcp_sub == "" or _mcp_sub == "status":
+                    # /mcp  or  /mcp status — show server overview
+                    if not use_mcp or mcp_engine is None:
+                        console.print(
+                            "[dim]MCP is not active for this session. "
+                            "Use --mcp-server or --mcp-all when launching interactive mode.[/dim]"
+                        )
+                    else:
+                        # Refresh tool counts from the registry
+                        tools_by_server = {}
+                        for _td in mcp_engine.list_tools():
+                            tools_by_server[_td.server_id] = (
+                                tools_by_server.get(_td.server_id, 0) + 1
+                            )
+
+                        _mcp_table = Table(
+                            title="MCP Servers",
+                            show_header=True,
+                            header_style="bold cyan",
+                        )
+                        _mcp_table.add_column("Server", style="cyan")
+                        _mcp_table.add_column("Status")
+                        _mcp_table.add_column("Tools")
+                        _mcp_table.add_column("Active")
+                        for _status in mcp_engine.list_servers():
+                            _is_active = _status.server_id in active_mcp_servers
+                            _tool_count = tools_by_server.get(_status.server_id, 0)
+                            if _status.status == "connected":
+                                _status_str = "[green]connected[/green]"
+                            elif _status.status in ("stopped", "disabled"):
+                                _status_str = f"[dim]{_status.status}[/dim]"
+                            else:
+                                _status_str = f"[red]{_status.status}[/red]"
+                            _tools_str = (
+                                f"[green]{_tool_count}[/green]"
+                                if _tool_count > 0
+                                else "[dim]—[/dim]"
+                            )
+                            _active_str = (
+                                "[green]yes[/green]" if _is_active else "[dim]no[/dim]"
+                            )
+                            _mcp_table.add_row(
+                                _status.server_id,
+                                _status_str,
+                                _tools_str,
+                                _active_str,
+                            )
+                        console.print(_mcp_table)
+
+                elif _mcp_sub == "on":
+                    # /mcp on <server_id> — start and activate a server
+                    if not use_mcp or mcp_engine is None:
+                        console.print("[dim]MCP is not active for this session.[/dim]")
+                    elif not _mcp_arg:
+                        console.print("[yellow]Usage: /mcp on <server_id>[/yellow]")
+                    else:
+                        _target_id = _mcp_arg
+                        _known_ids = [s.server_id for s in mcp_engine.list_servers()]
+                        if _target_id not in _known_ids:
+                            console.print(
+                                f"[yellow]Unknown MCP server: '{_target_id}'[/yellow]"
+                            )
+                        elif _target_id in active_mcp_servers:
+                            console.print(f"[dim]{_target_id} is already active[/dim]")
                         else:
-                            _status_str = f"[red]{_status.status}[/red]"
-                        _tools_str = (
-                            f"[green]{_tool_count}[/green]"
-                            if _is_active and _tool_count > 0
-                            else "[dim]—[/dim]"
+                            # Start the server if it isn't already connected
+                            _cur_status = mcp_engine.get_server_status(_target_id)
+                            if _cur_status.status != "connected":
+                                try:
+                                    with console.status(
+                                        f"[cyan]Starting MCP server: {_target_id}...",
+                                        spinner="dots",
+                                    ):
+                                        run_sync(mcp_engine.start_server(_target_id))
+                                except Exception as _start_exc:
+                                    console.print(
+                                        f"[red]Failed to start '{_target_id}': {_start_exc}[/red]"
+                                    )
+                                    console.print()
+                                    continue
+                            active_mcp_servers.append(_target_id)
+                            # Refresh tool counts
+                            tools_by_server = {}
+                            for _td in mcp_engine.list_tools():
+                                tools_by_server[_td.server_id] = (
+                                    tools_by_server.get(_td.server_id, 0) + 1
+                                )
+                            _tc = tools_by_server.get(_target_id, 0)
+                            console.print(
+                                f"[green]✓ Activated {_target_id}[/green] "
+                                f"[dim]({_tc} tools)[/dim]"
+                            )
+
+                elif _mcp_sub == "off":
+                    # /mcp off <server_id> — deactivate a server for this session
+                    if not use_mcp or mcp_engine is None:
+                        console.print("[dim]MCP is not active for this session.[/dim]")
+                    elif not _mcp_arg:
+                        console.print("[yellow]Usage: /mcp off <server_id>[/yellow]")
+                    else:
+                        _target_id = _mcp_arg
+                        if _target_id in active_mcp_servers:
+                            active_mcp_servers.remove(_target_id)
+                            console.print(
+                                f"[yellow]✓ Deactivated {_target_id}[/yellow] "
+                                "[dim](server still running)[/dim]"
+                            )
+                        else:
+                            console.print(
+                                f"[dim]{_target_id} is not in the active list[/dim]"
+                            )
+
+                elif _mcp_sub == "tools":
+                    # /mcp tools [server_id] — list discovered tools
+                    if not use_mcp or mcp_engine is None:
+                        console.print("[dim]MCP is not active for this session.[/dim]")
+                    else:
+                        _all_tools = mcp_engine.list_tools()
+                        if _mcp_arg:
+                            _all_tools = [
+                                t for t in _all_tools if t.server_id == _mcp_arg
+                            ]
+                            if not _all_tools:
+                                console.print(
+                                    f"[dim]No tools found for server '{_mcp_arg}'[/dim]"
+                                )
+                                console.print()
+                                continue
+
+                        _tool_table = Table(
+                            title="MCP Tools",
+                            show_header=True,
+                            header_style="bold cyan",
                         )
-                        _mcp_table.add_row(
-                            f"{_indicator}{_status.server_id}",
-                            _status_str,
-                            _tools_str,
-                        )
-                    console.print(_mcp_table)
+                        _tool_table.add_column("Namespace", style="cyan")
+                        _tool_table.add_column("Description")
+                        _tool_table.add_column("Permission")
+                        for _td in _all_tools:
+                            _desc = _td.description or ""
+                            if len(_desc) > 60:
+                                _desc = _desc[:57] + "..."
+                            _perm = mcp_engine._permission_manager.evaluate(
+                                _td.server_id, _td.tool_name
+                            )
+                            _perm_str = _perm.mode.value
+                            if _perm_str == "allow":
+                                _perm_display = "[green]allow[/green]"
+                            elif _perm_str == "confirm":
+                                _perm_display = "[yellow]confirm[/yellow]"
+                            else:
+                                _perm_display = "[red]deny[/red]"
+                            _tool_table.add_row(_td.namespace, _desc, _perm_display)
+                        console.print(_tool_table)
+
+                elif _mcp_sub == "refresh":
+                    # /mcp refresh — re-read local client configs
+                    if not use_mcp or mcp_engine is None:
+                        console.print("[dim]MCP is not active for this session.[/dim]")
+                    else:
+                        try:
+                            with console.status(
+                                "[cyan]Refreshing MCP server configs...",
+                                spinner="dots",
+                            ):
+                                run_sync(
+                                    mcp_engine.sync_configured_servers(client="auto")
+                                )
+                            # Refresh tool counts
+                            tools_by_server = {}
+                            for _td in mcp_engine.list_tools():
+                                tools_by_server[_td.server_id] = (
+                                    tools_by_server.get(_td.server_id, 0) + 1
+                                )
+                            _server_count = len(mcp_engine.list_servers())
+                            console.print(
+                                f"[green]✓ Refreshed[/green] "
+                                f"[dim]({_server_count} servers discovered)[/dim]"
+                            )
+                        except Exception as _refresh_exc:
+                            console.print(f"[red]Refresh failed: {_refresh_exc}[/red]")
+
+                else:
+                    console.print(
+                        f"[yellow]Unknown /mcp subcommand: {_mcp_sub}[/yellow]"
+                    )
+                    console.print(
+                        "[dim]Usage: /mcp [status] | /mcp on <id> | /mcp off <id> | /mcp tools [id] | /mcp refresh[/dim]"
+                    )
+
                 console.print()
                 continue
 
@@ -3360,27 +3521,41 @@ def interactive(
                 # Display help information
                 console.print("\n[bold cyan]Available Commands:[/bold cyan]")
                 console.print(
-                    "  [green]/file <path>[/green]   - Load and send file immediately"
+                    "  [green]/file <path>[/green]       - Load and send file immediately"
                 )
                 console.print(
-                    "  [green]/attach <path>[/green] - Stage file for next message"
+                    "  [green]/attach <path>[/green]     - Stage file for next message"
                 )
                 console.print(
-                    "  [green]/clear[/green]         - Clear staged attachments"
+                    "  [green]/clear[/green]             - Clear staged attachments"
                 )
                 console.print(
-                    "  [green]/save [path][/green]   - Save last response to file (markdown format)"
+                    "  [green]/save [path][/green]       - Save last response to file (markdown format)"
                 )
                 console.print(
-                    "  [green]/provider[/green]      - Switch provider and model"
+                    "  [green]/provider[/green]          - Switch provider and model"
                 )
                 console.print(
-                    "  [green]/mcp[/green]           - Show MCP server status"
+                    "  [green]/mcp[/green]               - Show MCP server status"
                 )
                 console.print(
-                    "  [green]/help[/green]          - Show this help message"
+                    "  [green]/mcp on <id>[/green]       - Activate an MCP server"
                 )
-                console.print("  [green]exit, quit, q[/green]  - Exit interactive mode")
+                console.print(
+                    "  [green]/mcp off <id>[/green]      - Deactivate an MCP server"
+                )
+                console.print(
+                    "  [green]/mcp tools [id][/green]    - List discovered MCP tools"
+                )
+                console.print(
+                    "  [green]/mcp refresh[/green]       - Re-read MCP server configs"
+                )
+                console.print(
+                    "  [green]/help[/green]              - Show this help message"
+                )
+                console.print(
+                    "  [green]exit, quit, q[/green]      - Exit interactive mode"
+                )
                 console.print("\n[bold cyan]Session Info:[/bold cyan]")
                 console.print(f"  Provider: [cyan]{provider}[/cyan]")
                 console.print(f"  Model: [cyan]{model}[/cyan]")
@@ -3389,6 +3564,10 @@ def interactive(
                 if staged_file_content:
                     console.print(
                         f"  Staged file: [yellow]📎 {staged_file_name}[/yellow]"
+                    )
+                if active_mcp_servers:
+                    console.print(
+                        f"  MCP active: [cyan]{', '.join(active_mcp_servers)}[/cyan]"
                     )
                 if last_response:
                     console.print("  Last response: [green]✓ Available to save[/green]")
@@ -3401,7 +3580,7 @@ def interactive(
                     f"[yellow]Unknown command: {user_input.split()[0]}[/yellow]"
                 )
                 console.print(
-                    "[dim]Available commands: /file, /attach, /mcp, /clear, /save, /provider, /help | Type 'exit' to quit[/dim]"
+                    "[dim]Available: /file, /attach, /mcp [on|off|tools|refresh], /clear, /save, /provider, /help | exit[/dim]"
                 )
                 continue
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ import pytest
 from typer.testing import CliRunner
 
 from cli.stratifyai_cli import app
+from stratifyai.mcp_client.permissions import PermissionDecision, PermissionMode
 from stratifyai.mcp_client.server_manager import ServerStatus
 from stratifyai.mcp_client.tool_registry import ToolDescriptor
 from stratifyai.models import ChatResponse, Usage
@@ -532,3 +533,477 @@ class TestMCPToolResultDisplay:
 
         assert result.exit_code == 0, result.output
         assert "MCP tools: 2" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — Interactive /mcp commands
+# ---------------------------------------------------------------------------
+
+
+def _make_rich_tool_descriptor(
+    server_id: str,
+    tool_name: str = "query",
+    description: str = "Execute a SQL query",
+) -> ToolDescriptor:
+    """Create a ToolDescriptor with all fields populated for /mcp tools tests.
+
+    Args:
+        server_id: The server ID to assign.
+        tool_name: The tool name to assign.
+        description: The tool description.
+
+    Returns:
+        A ToolDescriptor with populated fields.
+    """
+    td = MagicMock(spec=ToolDescriptor)
+    td.server_id = server_id
+    td.tool_name = tool_name
+    td.namespace = f"{server_id}.{tool_name}"
+    td.description = description
+    return td
+
+
+def _invoke_interactive_with_mcp_command(
+    runner: CliRunner,
+    simple_catalog: dict,
+    mock_engine: MagicMock,
+    mcp_command: str,
+    *,
+    extra_prompt_values: list[str] | None = None,
+):
+    """Invoke interactive mode, send an /mcp command, then exit.
+
+    Args:
+        runner: Typer CliRunner.
+        simple_catalog: Mocked MODEL_CATALOG dict.
+        mock_engine: Pre-configured MCPClientEngine mock.
+        mcp_command: The /mcp command to send (e.g. '/mcp tools').
+        extra_prompt_values: Additional prompt values before exit.
+
+    Returns:
+        The invocation Result.
+    """
+    prompt_values = ["", mcp_command]
+    if extra_prompt_values:
+        prompt_values.extend(extra_prompt_values)
+    prompt_values.append("exit")
+
+    return _invoke_interactive_with_mcp(
+        runner,
+        extra_args=["--mcp-server", "postgresql"],
+        simple_catalog=simple_catalog,
+        mock_engine=mock_engine,
+        prompt_side_effect=prompt_values,
+    )
+
+
+class TestMCPStatusCommand:
+    """Verify /mcp (or /mcp status) displays the server overview table (step 3.1)."""
+
+    def test_mcp_status_displays_server_list(
+        self, runner: CliRunner, simple_catalog: dict
+    ) -> None:
+        """'/mcp' must display a table with server IDs, status, and active column.
+
+        Args:
+            runner: Typer CliRunner fixture.
+            simple_catalog: Minimal model catalog fixture.
+        """
+        mock_engine = MagicMock()
+        mock_engine.list_servers.return_value = [
+            ServerStatus(server_id="postgresql", status="connected"),
+            ServerStatus(server_id="brave-search", status="stopped"),
+        ]
+        mock_engine.list_tools.return_value = [
+            _make_tool_descriptor("postgresql", "query"),
+            _make_tool_descriptor("postgresql", "schema"),
+        ]
+
+        result = _invoke_interactive_with_mcp_command(
+            runner, simple_catalog, mock_engine, "/mcp"
+        )
+
+        assert result.exit_code == 0, result.output
+        out = strip_ansi(result.output)
+        assert "postgresql" in out
+        assert "brave-search" in out
+        assert "connected" in out
+        assert "stopped" in out
+
+    def test_mcp_status_shows_active_column(
+        self, runner: CliRunner, simple_catalog: dict
+    ) -> None:
+        """The active column must show 'yes' for active servers and 'no' for others.
+
+        Args:
+            runner: Typer CliRunner fixture.
+            simple_catalog: Minimal model catalog fixture.
+        """
+        mock_engine = MagicMock()
+        mock_engine.list_servers.return_value = [
+            ServerStatus(server_id="postgresql", status="connected"),
+            ServerStatus(server_id="brave-search", status="stopped"),
+        ]
+        mock_engine.list_tools.return_value = [
+            _make_tool_descriptor("postgresql", "query"),
+        ]
+
+        result = _invoke_interactive_with_mcp_command(
+            runner, simple_catalog, mock_engine, "/mcp status"
+        )
+
+        assert result.exit_code == 0, result.output
+        out = strip_ansi(result.output)
+        # postgresql should be active (it was started via --mcp-server)
+        assert "yes" in out
+        # brave-search was not requested, so should show 'no'
+        assert "no" in out
+
+
+class TestMCPOnCommand:
+    """Verify /mcp on <server_id> activates a server for the session (step 3.2)."""
+
+    def test_mcp_on_adds_server_to_active_list(
+        self, runner: CliRunner, simple_catalog: dict
+    ) -> None:
+        """'/mcp on brave-search' must activate the server and show confirmation.
+
+        Args:
+            runner: Typer CliRunner fixture.
+            simple_catalog: Minimal model catalog fixture.
+        """
+        mock_engine = MagicMock()
+        mock_engine.list_servers.return_value = [
+            ServerStatus(server_id="postgresql", status="connected"),
+            ServerStatus(server_id="brave-search", status="stopped"),
+        ]
+        mock_engine.list_tools.return_value = [
+            _make_tool_descriptor("postgresql", "query"),
+        ]
+        mock_engine.get_server_status.return_value = ServerStatus(
+            server_id="brave-search", status="stopped"
+        )
+
+        result = _invoke_interactive_with_mcp_command(
+            runner, simple_catalog, mock_engine, "/mcp on brave-search"
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Activated brave-search" in strip_ansi(result.output)
+
+    def test_mcp_on_already_active_shows_message(
+        self, runner: CliRunner, simple_catalog: dict
+    ) -> None:
+        """'/mcp on postgresql' when already active must say so.
+
+        Args:
+            runner: Typer CliRunner fixture.
+            simple_catalog: Minimal model catalog fixture.
+        """
+        mock_engine = MagicMock()
+        mock_engine.list_servers.return_value = [
+            ServerStatus(server_id="postgresql", status="connected"),
+        ]
+        mock_engine.list_tools.return_value = [
+            _make_tool_descriptor("postgresql", "query"),
+        ]
+
+        result = _invoke_interactive_with_mcp_command(
+            runner, simple_catalog, mock_engine, "/mcp on postgresql"
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "already active" in strip_ansi(result.output)
+
+    def test_mcp_on_unknown_server_shows_warning(
+        self, runner: CliRunner, simple_catalog: dict
+    ) -> None:
+        """'/mcp on nonexistent' must warn about unknown server.
+
+        Args:
+            runner: Typer CliRunner fixture.
+            simple_catalog: Minimal model catalog fixture.
+        """
+        mock_engine = MagicMock()
+        mock_engine.list_servers.return_value = [
+            ServerStatus(server_id="postgresql", status="connected"),
+        ]
+        mock_engine.list_tools.return_value = [
+            _make_tool_descriptor("postgresql", "query"),
+        ]
+
+        result = _invoke_interactive_with_mcp_command(
+            runner, simple_catalog, mock_engine, "/mcp on nonexistent"
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Unknown MCP server" in strip_ansi(result.output)
+
+
+class TestMCPOffCommand:
+    """Verify /mcp off <server_id> deactivates a server for the session (step 3.2)."""
+
+    def test_mcp_off_removes_server_from_active_list(
+        self, runner: CliRunner, simple_catalog: dict
+    ) -> None:
+        """'/mcp off postgresql' must deactivate the server.
+
+        Args:
+            runner: Typer CliRunner fixture.
+            simple_catalog: Minimal model catalog fixture.
+        """
+        mock_engine = MagicMock()
+        mock_engine.list_servers.return_value = [
+            ServerStatus(server_id="postgresql", status="connected"),
+        ]
+        mock_engine.list_tools.return_value = [
+            _make_tool_descriptor("postgresql", "query"),
+        ]
+
+        result = _invoke_interactive_with_mcp_command(
+            runner, simple_catalog, mock_engine, "/mcp off postgresql"
+        )
+
+        assert result.exit_code == 0, result.output
+        out = strip_ansi(result.output)
+        assert "Deactivated postgresql" in out
+        assert "server still running" in out
+
+    def test_mcp_off_not_active_shows_message(
+        self, runner: CliRunner, simple_catalog: dict
+    ) -> None:
+        """'/mcp off brave-search' when not active must say so.
+
+        Args:
+            runner: Typer CliRunner fixture.
+            simple_catalog: Minimal model catalog fixture.
+        """
+        mock_engine = MagicMock()
+        mock_engine.list_servers.return_value = [
+            ServerStatus(server_id="postgresql", status="connected"),
+        ]
+        mock_engine.list_tools.return_value = [
+            _make_tool_descriptor("postgresql", "query"),
+        ]
+
+        result = _invoke_interactive_with_mcp_command(
+            runner, simple_catalog, mock_engine, "/mcp off brave-search"
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "not in the active list" in strip_ansi(result.output)
+
+
+class TestMCPToolsCommand:
+    """Verify /mcp tools lists discovered MCP tools (step 3.3)."""
+
+    def test_mcp_tools_lists_all_tools(
+        self, runner: CliRunner, simple_catalog: dict
+    ) -> None:
+        """'/mcp tools' must display namespace, description, and permission.
+
+        Args:
+            runner: Typer CliRunner fixture.
+            simple_catalog: Minimal model catalog fixture.
+        """
+        perm_mock = MagicMock()
+        perm_mock.evaluate.return_value = PermissionDecision(
+            mode=PermissionMode.ALLOW, reason="test"
+        )
+
+        mock_engine = MagicMock()
+        mock_engine.list_servers.return_value = [
+            ServerStatus(server_id="postgresql", status="connected"),
+        ]
+        mock_engine.list_tools.return_value = [
+            _make_rich_tool_descriptor("postgresql", "query", "Execute a SQL query"),
+            _make_rich_tool_descriptor("postgresql", "schema", "Get table schema"),
+        ]
+        mock_engine._permission_manager = perm_mock
+
+        result = _invoke_interactive_with_mcp_command(
+            runner, simple_catalog, mock_engine, "/mcp tools"
+        )
+
+        assert result.exit_code == 0, result.output
+        out = strip_ansi(result.output)
+        assert "postgresql.query" in out
+        assert "postgresql.schema" in out
+        assert "Execute a SQL query" in out
+        assert "allow" in out
+
+    def test_mcp_tools_filters_by_server_id(
+        self, runner: CliRunner, simple_catalog: dict
+    ) -> None:
+        """'/mcp tools postgresql' must only show tools for that server.
+
+        Args:
+            runner: Typer CliRunner fixture.
+            simple_catalog: Minimal model catalog fixture.
+        """
+        perm_mock = MagicMock()
+        perm_mock.evaluate.return_value = PermissionDecision(
+            mode=PermissionMode.ALLOW, reason="test"
+        )
+
+        mock_engine = MagicMock()
+        mock_engine.list_servers.return_value = [
+            ServerStatus(server_id="postgresql", status="connected"),
+        ]
+        mock_engine.list_tools.return_value = [
+            _make_rich_tool_descriptor("postgresql", "query"),
+            _make_rich_tool_descriptor("filesystem", "read_file", "Read a file"),
+        ]
+        mock_engine._permission_manager = perm_mock
+
+        result = _invoke_interactive_with_mcp_command(
+            runner, simple_catalog, mock_engine, "/mcp tools postgresql"
+        )
+
+        assert result.exit_code == 0, result.output
+        out = strip_ansi(result.output)
+        assert "postgresql.query" in out
+        # filesystem tools should NOT appear
+        assert "filesystem.read_file" not in out
+
+    def test_mcp_tools_unknown_server_shows_empty(
+        self, runner: CliRunner, simple_catalog: dict
+    ) -> None:
+        """'/mcp tools nonexistent' must show no-tools message.
+
+        Args:
+            runner: Typer CliRunner fixture.
+            simple_catalog: Minimal model catalog fixture.
+        """
+        mock_engine = MagicMock()
+        mock_engine.list_servers.return_value = [
+            ServerStatus(server_id="postgresql", status="connected"),
+        ]
+        mock_engine.list_tools.return_value = [
+            _make_rich_tool_descriptor("postgresql", "query"),
+        ]
+
+        result = _invoke_interactive_with_mcp_command(
+            runner, simple_catalog, mock_engine, "/mcp tools nonexistent"
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "No tools found" in strip_ansi(result.output)
+
+
+class TestMCPRefreshCommand:
+    """Verify /mcp refresh re-reads local client configs (step 3.4)."""
+
+    def test_mcp_refresh_calls_sync(
+        self, runner: CliRunner, simple_catalog: dict
+    ) -> None:
+        """'/mcp refresh' must invoke sync_configured_servers on the engine.
+
+        Args:
+            runner: Typer CliRunner fixture.
+            simple_catalog: Minimal model catalog fixture.
+        """
+        mock_engine = MagicMock()
+        mock_engine.list_servers.return_value = [
+            ServerStatus(server_id="postgresql", status="connected"),
+        ]
+        mock_engine.list_tools.return_value = [
+            _make_tool_descriptor("postgresql", "query"),
+        ]
+
+        # Track whether run_sync was called with the sync coroutine
+        sync_called = []
+
+        def track_run_sync(coro=None):
+            """Track calls to run_sync, identifying sync_configured_servers."""
+            if coro is not None:
+                sync_called.append(str(coro))
+            return None
+
+        base_args = [
+            "interactive",
+            "--provider",
+            "openai",
+            "--model",
+            "gpt-4o-mini",
+            "--mcp-server",
+            "postgresql",
+        ]
+
+        with (
+            patch("cli.stratifyai_cli.MODEL_CATALOG", simple_catalog),
+            patch("cli.stratifyai_cli.LLMClient"),
+            patch(
+                "stratifyai.mcp_client.MCPClientEngine",
+                return_value=mock_engine,
+            ),
+            patch("cli.stratifyai_cli.run_sync", side_effect=track_run_sync),
+            patch(
+                "cli.stratifyai_cli.Prompt.ask",
+                side_effect=["", "/mcp refresh", "exit"],
+            ),
+        ):
+            result = runner.invoke(app, base_args)
+
+        assert result.exit_code == 0, result.output
+        assert "Refreshed" in strip_ansi(result.output)
+        # sync_configured_servers must have been called (via run_sync)
+        mock_engine.sync_configured_servers.assert_called_once_with(client="auto")
+
+
+class TestMCPHelpUpdate:
+    """Verify /help output includes the new /mcp subcommands (step 3.5)."""
+
+    def test_help_includes_mcp_subcommands(
+        self, runner: CliRunner, simple_catalog: dict
+    ) -> None:
+        """'/help' must list /mcp on, /mcp off, /mcp tools, /mcp refresh.
+
+        Args:
+            runner: Typer CliRunner fixture.
+            simple_catalog: Minimal model catalog fixture.
+        """
+        mock_engine = MagicMock()
+        mock_engine.list_servers.return_value = [
+            ServerStatus(server_id="postgresql", status="connected"),
+        ]
+        mock_engine.list_tools.return_value = [
+            _make_tool_descriptor("postgresql", "query"),
+        ]
+
+        result = _invoke_interactive_with_mcp_command(
+            runner, simple_catalog, mock_engine, "/help"
+        )
+
+        assert result.exit_code == 0, result.output
+        out = strip_ansi(result.output)
+        assert "/mcp on <id>" in out
+        assert "/mcp off <id>" in out
+        assert "/mcp tools" in out
+        assert "/mcp refresh" in out
+
+    def test_help_shows_active_mcp_servers(
+        self, runner: CliRunner, simple_catalog: dict
+    ) -> None:
+        """'/help' session info must show active MCP servers.
+
+        Args:
+            runner: Typer CliRunner fixture.
+            simple_catalog: Minimal model catalog fixture.
+        """
+        mock_engine = MagicMock()
+        mock_engine.list_servers.return_value = [
+            ServerStatus(server_id="postgresql", status="connected"),
+        ]
+        mock_engine.list_tools.return_value = [
+            _make_tool_descriptor("postgresql", "query"),
+        ]
+
+        result = _invoke_interactive_with_mcp_command(
+            runner, simple_catalog, mock_engine, "/help"
+        )
+
+        assert result.exit_code == 0, result.output
+        out = strip_ansi(result.output)
+        assert "MCP active:" in out
+        assert "postgresql" in out

--- a/tests/test_provider_validator.py
+++ b/tests/test_provider_validator.py
@@ -236,3 +236,266 @@ class TestProviderValidator:
         assert mock_validate.call_args.args[0] == "openai"
         assert isinstance(mock_validate.call_args.args[1], list)
         assert len(mock_validate.call_args.args[1]) >= 1
+
+
+# ---------------------------------------------------------------------------
+# OpenAI error paths (lines 83-88)
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIErrorPaths:
+    @patch("openai.OpenAI")
+    @patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}, clear=True)
+    def test_validate_openai_generic_exception(self, mock_openai):
+        mock_openai.return_value.models.list.side_effect = RuntimeError("API down")
+
+        result = _validate_openai(["gpt-4o-mini"])
+
+        assert "Validation failed" in result["error"]
+        assert result["valid_models"] == ["gpt-4o-mini"]
+        assert result["validation_time_ms"] >= 0
+
+    def test_validate_openai_import_error(self):
+        with patch.dict("sys.modules", {"openai": None}):
+            result = _validate_openai(["gpt-4o-mini"])
+
+        assert "not installed" in result["error"]
+        assert result["valid_models"] == ["gpt-4o-mini"]
+
+
+# ---------------------------------------------------------------------------
+# Anthropic paths (lines 107-121, 131-139)
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicPaths:
+    @patch.dict("os.environ", {}, clear=True)
+    def test_validate_anthropic_missing_key(self):
+        result = _validate_anthropic(["claude-3-5-sonnet-20241022"])
+
+        assert result["error"] == "ANTHROPIC_API_KEY not configured"
+        assert result["valid_models"] == ["claude-3-5-sonnet-20241022"]
+
+    @patch("anthropic.Anthropic")
+    @patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-ant-test"}, clear=True)
+    def test_validate_anthropic_success(self, mock_anthropic):
+        client = MagicMock()
+        client.models.list.return_value = MagicMock(
+            data=[MagicMock(id="claude-3-5-sonnet-20241022")]
+        )
+        mock_anthropic.return_value = client
+
+        result = _validate_anthropic(["claude-3-5-sonnet-20241022", "missing-model"])
+
+        assert result["valid_models"] == ["claude-3-5-sonnet-20241022"]
+        assert result["invalid_models"] == ["missing-model"]
+        assert result["error"] is None
+
+    @patch("anthropic.Anthropic")
+    @patch.dict("os.environ", {"ANTHROPIC_API_KEY": "bad-key"}, clear=True)
+    def test_validate_anthropic_old_sdk_invalid_key_format(self, mock_anthropic):
+        client = MagicMock()
+        client.models.list.side_effect = AttributeError("old sdk")
+        mock_anthropic.return_value = client
+
+        result = _validate_anthropic(["claude-3-5-sonnet-20241022"])
+
+        assert "Invalid API key format" in result["error"]
+        assert result["valid_models"] == ["claude-3-5-sonnet-20241022"]
+
+    def test_validate_anthropic_import_error(self):
+        with patch.dict("sys.modules", {"anthropic": None}):
+            result = _validate_anthropic(["claude-3-5-sonnet-20241022"])
+
+        assert "not installed" in result["error"]
+        assert result["valid_models"] == ["claude-3-5-sonnet-20241022"]
+
+    @patch("anthropic.Anthropic")
+    @patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-ant-test"}, clear=True)
+    def test_validate_anthropic_generic_exception(self, mock_anthropic):
+        mock_anthropic.side_effect = RuntimeError("connection error")
+
+        result = _validate_anthropic(["claude-3-5-sonnet-20241022"])
+
+        assert "Validation failed" in result["error"]
+        assert result["valid_models"] == ["claude-3-5-sonnet-20241022"]
+
+
+# ---------------------------------------------------------------------------
+# Google edge cases (lines 174, 178, 194-199)
+# ---------------------------------------------------------------------------
+
+
+class TestGoogleEdgeCases:
+    @patch("google.genai.Client")
+    @patch.dict("os.environ", {"GOOGLE_API_KEY": "google-key"}, clear=True)
+    def test_validate_google_non_string_name_skipped(self, mock_client_class):
+        """Model with non-string name attribute is skipped."""
+        bad_model = MagicMock()
+        bad_model.name = 12345  # not a string
+        del bad_model._mock_name  # no fallback either
+
+        client = MagicMock()
+        client.models.list.return_value = [bad_model]
+        mock_client_class.return_value = client
+
+        result = _validate_google(["gemini-2.5-flash"])
+
+        assert result["invalid_models"] == ["gemini-2.5-flash"]
+
+    @patch("google.genai.Client")
+    @patch.dict("os.environ", {"GOOGLE_API_KEY": "google-key"}, clear=True)
+    def test_validate_google_empty_name_skipped(self, mock_client_class):
+        """Model whose name resolves to empty string is skipped."""
+        model = MagicMock()
+        model.name = "models/"  # resolves to empty after replace
+
+        client = MagicMock()
+        client.models.list.return_value = [model]
+        mock_client_class.return_value = client
+
+        result = _validate_google(["gemini-2.5-flash"])
+
+        assert result["invalid_models"] == ["gemini-2.5-flash"]
+
+    def test_validate_google_import_error(self):
+        with patch.dict("sys.modules", {"google": None, "google.genai": None}):
+            result = _validate_google(["gemini-2.5-flash"])
+
+        assert "not installed" in result["error"]
+        assert result["valid_models"] == ["gemini-2.5-flash"]
+
+    @patch("google.genai.Client")
+    @patch.dict("os.environ", {"GOOGLE_API_KEY": "google-key"}, clear=True)
+    def test_validate_google_generic_exception(self, mock_client_class):
+        mock_client_class.side_effect = RuntimeError("quota exceeded")
+
+        result = _validate_google(["gemini-2.5-flash"])
+
+        assert "Validation failed" in result["error"]
+        assert result["valid_models"] == ["gemini-2.5-flash"]
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible error paths (lines 243-248)
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAICompatibleErrorPaths:
+    def test_validate_compatible_import_error(self):
+        with patch.dict("sys.modules", {"httpx": None}):
+            result = _validate_openai_compatible(
+                ["model-a"], "https://example.com/v1", None, "DEMO_KEY"
+            )
+
+        assert "not installed" in result["error"]
+        assert result["valid_models"] == ["model-a"]
+
+    @patch("httpx.Client")
+    @patch.dict("os.environ", {"DEMO_KEY": "test-key"}, clear=True)
+    def test_validate_compatible_generic_exception(self, mock_client_class):
+        client_cm = MagicMock()
+        client_cm.__enter__.return_value.get.side_effect = RuntimeError("timeout")
+        client_cm.__exit__.return_value = None
+        mock_client_class.return_value = client_cm
+
+        result = _validate_openai_compatible(
+            ["model-a"], "https://example.com/v1", None, "DEMO_KEY"
+        )
+
+        assert "Validation failed" in result["error"]
+        assert result["valid_models"] == ["model-a"]
+
+
+# ---------------------------------------------------------------------------
+# DeepSeek / Groq delegation (lines 259, 269)
+# ---------------------------------------------------------------------------
+
+
+class TestDelegationWrappers:
+    @patch("stratifyai.utils.provider_validator._validate_openai_compatible")
+    def test_validate_deepseek_delegates(self, mock_validate):
+        mock_validate.return_value = {
+            "valid_models": ["deepseek-chat"],
+            "invalid_models": [],
+            "validation_time_ms": 1,
+            "error": None,
+        }
+        result = validate_provider_models("deepseek", ["deepseek-chat"])
+        assert result["valid_models"] == ["deepseek-chat"]
+        mock_validate.assert_called_once()
+
+    @patch("stratifyai.utils.provider_validator._validate_openai_compatible")
+    def test_validate_groq_delegates(self, mock_validate):
+        mock_validate.return_value = {
+            "valid_models": ["llama-3.3-70b-versatile"],
+            "invalid_models": [],
+            "validation_time_ms": 1,
+            "error": None,
+        }
+        result = validate_provider_models("groq", ["llama-3.3-70b-versatile"])
+        assert result["valid_models"] == ["llama-3.3-70b-versatile"]
+        mock_validate.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# OpenRouter error paths (lines 301-303, 326-331)
+# ---------------------------------------------------------------------------
+
+
+class TestOpenRouterErrorPaths:
+    @patch.dict("os.environ", {}, clear=True)
+    def test_validate_openrouter_missing_key(self):
+        result = _validate_openrouter(["openai/gpt-4o-mini"])
+
+        assert result["error"] == "OPENROUTER_API_KEY not configured"
+        assert result["valid_models"] == ["openai/gpt-4o-mini"]
+
+    def test_validate_openrouter_import_error(self):
+        with patch.dict("sys.modules", {"httpx": None}):
+            result = _validate_openrouter(["openai/gpt-4o-mini"])
+
+        assert "not installed" in result["error"]
+        assert result["valid_models"] == ["openai/gpt-4o-mini"]
+
+    @patch("httpx.Client")
+    @patch.dict("os.environ", {"OPENROUTER_API_KEY": "key"}, clear=True)
+    def test_validate_openrouter_generic_exception(self, mock_client_class):
+        client_cm = MagicMock()
+        client_cm.__enter__.return_value.get.side_effect = RuntimeError("down")
+        client_cm.__exit__.return_value = None
+        mock_client_class.return_value = client_cm
+
+        result = _validate_openrouter(["openai/gpt-4o-mini"])
+
+        assert "Validation failed" in result["error"]
+        assert result["valid_models"] == ["openai/gpt-4o-mini"]
+
+
+# ---------------------------------------------------------------------------
+# Ollama non-connection error (lines 371-372, 378)
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaErrorPaths:
+    @patch("httpx.Client")
+    def test_validate_ollama_generic_non_connection_error(self, mock_client_class):
+        client_cm = MagicMock()
+        client_cm.__enter__.return_value.get.side_effect = RuntimeError(
+            "unexpected error"
+        )
+        client_cm.__exit__.return_value = None
+        mock_client_class.return_value = client_cm
+
+        result = _validate_ollama(["llama3.2"])
+
+        assert "Validation failed" in result["error"]
+        assert "Ollama not running" not in result["error"]
+        assert result["valid_models"] == ["llama3.2"]
+
+    def test_validate_ollama_import_error(self):
+        with patch.dict("sys.modules", {"httpx": None}):
+            result = _validate_ollama(["llama3.2"])
+
+        assert "not installed" in result["error"]
+        assert result["valid_models"] == ["llama3.2"]


### PR DESCRIPTION
feat(cli): implement runtime commands

Closes #76

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements Phase 3 of the interactive MCP CLI feature: a `/mcp` subcommand dispatcher (status, on, off, tools, refresh) wired inline into the interactive session loop, plus help-text updates and corresponding tests. The implementation is well-structured and the test coverage is thorough, but there is one P1 robustness gap in the `/mcp on` handler where `get_server_status` can crash the entire interactive session.

- **P1** — `mcp_engine.get_server_status(_target_id)` (line 3394) is called outside any `try/except`; a failure propagates to the outer `except Exception` handler, which calls `raise typer.Exit(1)` and terminates the session. The adjacent `start_server` call is properly guarded — `get_server_status` should be too.
- **P2** — `/mcp tools` (no server filter) renders an empty Rich table when there are no tools, while the filtered path shows a user-friendly message; the two paths should be consistent.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the unguarded get_server_status call that can crash the interactive session.

One P1 bug exists in /mcp on: get_server_status is not wrapped in try/except, meaning any transient engine failure terminates the user's interactive session via raise typer.Exit(1). The fix is a small, localized change. All other findings are P2 or lower. Tests are thorough and the overall feature is well-implemented.

cli/stratifyai_cli.py line 3394 — the get_server_status call in the /mcp on handler

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| cli/stratifyai_cli.py | Adds Phase 3 /mcp runtime command dispatcher (status, on, off, tools, refresh) inline in the interactive loop; `get_server_status` in /mcp on is unguarded and can crash the session if it throws. |
| tests/test_cli.py | Adds comprehensive Phase 3 tests for /mcp status, on, off, tools, refresh, and /help output; test helpers are well-structured and cover both happy and error paths. |
| tests/test_provider_validator.py | Extends provider validator unit tests with edge-case and error-path coverage for all providers; no issues found. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: cli/stratifyai_cli.py
Line: 3394

Comment:
**`get_server_status` is unguarded and can crash the session**

`mcp_engine.get_server_status(_target_id)` is called outside any `try/except`, while the very next `start_server` call (line 3401) is fully protected. If the server manager throws here — e.g., due to an IPC failure or a stale connection — the exception escapes to the outer `except Exception` at line 3844, which calls `raise typer.Exit(1)` and terminates the entire interactive session, discarding the user's conversation history.

```suggestion
                            try:
                                _cur_status = mcp_engine.get_server_status(_target_id)
                            except Exception as _status_exc:
                                console.print(
                                    f"[red]Could not query '{_target_id}' status: {_status_exc}[/red]"
                                )
                                console.print()
                                continue
                            if _cur_status.status != "connected":
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: cli/stratifyai_cli.py
Line: 3445-3455

Comment:
**`/mcp tools` shows empty table instead of "no tools" message**

When `_mcp_arg` is empty (show all tools) but `_all_tools` is empty, the code falls through to render an empty Rich table. When `_mcp_arg` is set but yields no match, a friendly "No tools found…" message is shown and the loop continues. The two paths are inconsistent and an empty table is confusing.

```suggestion
                        _all_tools = mcp_engine.list_tools()
                        if _mcp_arg:
                            _all_tools = [
                                t for t in _all_tools if t.server_id == _mcp_arg
                            ]
                            if not _all_tools:
                                console.print(
                                    f"[dim]No tools found for server '{_mcp_arg}'[/dim]"
                                )
                                console.print()
                                continue
                        if not _all_tools:
                            console.print("[dim]No MCP tools discovered.[/dim]")
                            console.print()
                            continue
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: cli/stratifyai_cli.py
Line: 3322-3325

Comment:
**`startswith("/mcp")` catches run-together typos as status queries**

`user_input.lower().startswith("/mcp")` matches inputs like `/mcpstatus` or `/mcptools` (no space). `user_input.split(maxsplit=2)` then produces a single-element list, so `_mcp_sub` is `""`, and the MCP status table is silently displayed. A user who mistypes `/mcptools` would see a table instead of an "unknown command" hint.

Consider requiring a word boundary, e.g.:

```python
elif user_input.lower().split(maxsplit=1)[0] == "/mcp":
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(cli): implement runtime commands"](https://github.com/bytes0211/stratifyai/commit/4775815f6fc1b11685e3cb19b5ed2d4627aa84a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28113156)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->